### PR TITLE
Create landing page with demo selection

### DIFF
--- a/cards-stream/api/github/index.html
+++ b/cards-stream/api/github/index.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>GitHub Issues/PRs - Focus Mode - API</title>
+    <link rel="stylesheet" href="../../../shared/css/operator.css">
+
+    <!-- React and ReactDOM from CDN -->
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+    <!-- Babel Standalone for JSX transformation -->
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+</head>
+<body>
+    <div id="root"></div>
+
+    <script src="../../../shared/js/auth-utils.js"></script>
+    <script src="../../../shared/js/ui-components.js"></script>
+    <script type="text/babel">
+        const { useState } = React;
+
+        // Custom content renderer for GitHub issues/PRs
+        function renderGitHubContent(item) {
+            return React.createElement('div', null,
+                React.createElement('div', { className: 'card-content' }, item.body),
+                item.labels && item.labels.length > 0 &&
+                    React.createElement('div', { className: 'issue-labels' },
+                        item.labels.map((label, idx) =>
+                            React.createElement('span', {
+                                key: idx,
+                                className: `label ${label}`
+                            }, label)
+                        )
+                    ),
+                React.createElement('div', { className: 'user-info' },
+                    React.createElement('img', {
+                        src: item.user.avatar_url,
+                        alt: item.user.login,
+                        className: 'user-avatar'
+                    }),
+                    React.createElement('div', null,
+                        React.createElement('div', { className: 'user-name' }, item.user.login),
+                        React.createElement('div', {
+                            style: { fontSize: '0.875rem', color: 'var(--text-secondary)' }
+                        }, `#${item.number}`)
+                    )
+                )
+            );
+        }
+
+        // Fetch GitHub data (using mock data for demo)
+        async function fetchGitHubData() {
+            await new Promise(resolve => setTimeout(resolve, 1000));
+
+            const issues = MockDataGenerators.github.generateIssues(5);
+            const prs = MockDataGenerators.github.generatePullRequests(3);
+
+            const combined = [...issues, ...prs].map(item => {
+                const timeAgo = new Date(item.created_at);
+                const now = new Date();
+                const diffHours = Math.floor((now - timeAgo) / (1000 * 60 * 60));
+
+                return {
+                    ...item,
+                    source: item.pull_request ? 'Pull Request' : 'Issue',
+                    type: item.pull_request ? 'Pull Request' : 'Issue',
+                    title: item.title,
+                    content: item.body,
+                    time: diffHours < 1 ? 'Just now' :
+                           diffHours < 24 ? `${diffHours}h ago` :
+                           `${Math.floor(diffHours / 24)}d ago`,
+                    timeAgo: diffHours < 1 ? 'Just now' :
+                            diffHours < 24 ? `${diffHours}h ago` :
+                            `${Math.floor(diffHours / 24)}d ago`
+                };
+            });
+
+            return combined;
+        }
+
+        // Render the app
+        const root = ReactDOM.createRoot(document.getElementById('root'));
+        root.render(
+            React.createElement(CardsStreamApp, {
+                title: 'GitHub Issues & PRs (Focus)',
+                fetchData: fetchGitHubData,
+                renderContent: renderGitHubContent,
+                platform: 'GitHub'
+            })
+        );
+    </script>
+</body>
+</html>

--- a/cards-stream/api/telegram/index.html
+++ b/cards-stream/api/telegram/index.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Telegram Messages - Focus Mode - API</title>
+    <link rel="stylesheet" href="../../../shared/css/operator.css">
+
+    <!-- React and ReactDOM from CDN -->
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+    <!-- Babel Standalone for JSX transformation -->
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+</head>
+<body>
+    <div id="root"></div>
+
+    <script src="../../../shared/js/auth-utils.js"></script>
+    <script src="../../../shared/js/ui-components.js"></script>
+    <script type="text/babel">
+        const { useState } = React;
+
+        // Custom content renderer for Telegram messages
+        function renderTelegramContent(item) {
+            return React.createElement('div', null,
+                React.createElement('div', { className: 'message-content' }, item.text),
+                React.createElement('div', { className: 'message-meta' },
+                    React.createElement('div', null,
+                        React.createElement('strong', null, 'From: '),
+                        item.from.first_name,
+                        ' (@', item.from.username, ')'
+                    ),
+                    React.createElement('div', null,
+                        React.createElement('span', {
+                            style: {
+                                background: '#10b981',
+                                padding: '0.25rem 0.5rem',
+                                borderRadius: '0.25rem',
+                                fontSize: '0.75rem',
+                                color: 'white'
+                            }
+                        }, 'UNREAD')
+                    )
+                )
+            );
+        }
+
+        // Fetch Telegram data (using mock data for demo)
+        async function fetchTelegramData() {
+            await new Promise(resolve => setTimeout(resolve, 1000));
+
+            const messages = MockDataGenerators.telegram.generateMessages(8);
+
+            return messages.map(msg => {
+                const timeAgo = Date.now() / 1000 - msg.date;
+                const hours = Math.floor(timeAgo / 3600);
+
+                return {
+                    ...msg,
+                    source: 'Telegram',
+                    type: 'Private Message',
+                    title: `Message from ${msg.from.first_name}`,
+                    content: msg.text,
+                    time: hours < 1 ? 'Just now' :
+                           hours < 24 ? `${hours}h ago` :
+                           `${Math.floor(hours / 24)}d ago`,
+                    timeAgo: hours < 1 ? 'Just now' :
+                            hours < 24 ? `${hours}h ago` :
+                            `${Math.floor(hours / 24)}d ago`
+                };
+            });
+        }
+
+        // Render the app
+        const root = ReactDOM.createRoot(document.getElementById('root'));
+        root.render(
+            React.createElement(CardsStreamApp, {
+                title: 'Telegram Messages (Focus)',
+                fetchData: fetchTelegramData,
+                renderContent: renderTelegramContent,
+                platform: 'Telegram'
+            })
+        );
+    </script>
+</body>
+</html>

--- a/cards-stream/api/vk/index.html
+++ b/cards-stream/api/vk/index.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>VK Messages - Focus Mode - API</title>
+    <link rel="stylesheet" href="../../../shared/css/operator.css">
+
+    <!-- React and ReactDOM from CDN -->
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+    <!-- Babel Standalone for JSX transformation -->
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+</head>
+<body>
+    <div id="root"></div>
+
+    <script src="../../../shared/js/auth-utils.js"></script>
+    <script src="../../../shared/js/ui-components.js"></script>
+    <script type="text/babel">
+        const { useState } = React;
+
+        // Custom content renderer for VK messages
+        function renderVKContent(item) {
+            return React.createElement('div', null,
+                React.createElement('div', { className: 'message-content' }, item.text),
+                React.createElement('div', { className: 'message-meta' },
+                    React.createElement('div', null,
+                        React.createElement('strong', null, 'From: '),
+                        item.first_name,
+                        ' (ID: ', item.user_id, ')'
+                    ),
+                    React.createElement('div', null,
+                        React.createElement('span', {
+                            style: {
+                                background: '#07f',
+                                padding: '0.25rem 0.5rem',
+                                borderRadius: '0.25rem',
+                                fontSize: '0.75rem',
+                                color: 'white'
+                            }
+                        }, 'UNREAD')
+                    )
+                )
+            );
+        }
+
+        // Fetch VK data (using mock data for demo)
+        async function fetchVKData() {
+            await new Promise(resolve => setTimeout(resolve, 1000));
+
+            const messages = MockDataGenerators.vk.generateMessages(8);
+
+            return messages.map(msg => {
+                const timeAgo = Date.now() / 1000 - msg.date;
+                const hours = Math.floor(timeAgo / 3600);
+
+                return {
+                    ...msg,
+                    source: 'VK',
+                    type: 'Private Message',
+                    title: `Message from ${msg.first_name}`,
+                    content: msg.text,
+                    time: hours < 1 ? 'Just now' :
+                           hours < 24 ? `${hours}h ago` :
+                           `${Math.floor(hours / 24)}d ago`,
+                    timeAgo: hours < 1 ? 'Just now' :
+                            hours < 24 ? `${hours}h ago` :
+                            `${Math.floor(hours / 24)}d ago`
+                };
+            });
+        }
+
+        // Render the app
+        const root = ReactDOM.createRoot(document.getElementById('root'));
+        root.render(
+            React.createElement(CardsStreamApp, {
+                title: 'VK Messages (Focus)',
+                fetchData: fetchVKData,
+                renderContent: renderVKContent,
+                platform: 'VK'
+            })
+        );
+    </script>
+</body>
+</html>

--- a/cards-stream/api/x/index.html
+++ b/cards-stream/api/x/index.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>X (Twitter) DMs - Focus Mode - API</title>
+    <link rel="stylesheet" href="../../../shared/css/operator.css">
+
+    <!-- React and ReactDOM from CDN -->
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+    <!-- Babel Standalone for JSX transformation -->
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+</head>
+<body>
+    <div id="root"></div>
+
+    <script src="../../../shared/js/auth-utils.js"></script>
+    <script src="../../../shared/js/ui-components.js"></script>
+    <script type="text/babel">
+        const { useState } = React;
+
+        // Custom content renderer for X DMs
+        function renderXContent(item) {
+            return React.createElement('div', null,
+                React.createElement('div', { className: 'message-content' }, item.text),
+                React.createElement('div', { className: 'user-info' },
+                    React.createElement('img', {
+                        src: item.sender.profile_image_url,
+                        alt: item.sender.username,
+                        className: 'user-avatar'
+                    }),
+                    React.createElement('div', null,
+                        React.createElement('div', { className: 'user-name' },
+                            item.sender.name,
+                            ' (@', item.sender.username, ')'
+                        ),
+                        React.createElement('div', {
+                            style: { fontSize: '0.875rem', color: 'var(--text-secondary)' }
+                        },
+                            React.createElement('span', {
+                                style: {
+                                    background: '#1d9bf0',
+                                    padding: '0.25rem 0.5rem',
+                                    borderRadius: '0.25rem',
+                                    fontSize: '0.75rem',
+                                    color: 'white'
+                                }
+                            }, 'UNREAD')
+                        )
+                    )
+                )
+            );
+        }
+
+        // Fetch X (Twitter) data (using mock data for demo)
+        async function fetchXData() {
+            await new Promise(resolve => setTimeout(resolve, 1000));
+
+            const dms = MockDataGenerators.x.generateDMs(6);
+
+            return dms.map(dm => {
+                const timeAgo = new Date(dm.created_at);
+                const now = new Date();
+                const diffHours = Math.floor((now - timeAgo) / (1000 * 60 * 60));
+
+                return {
+                    ...dm,
+                    source: 'X (Twitter)',
+                    type: 'Direct Message',
+                    title: `DM from @${dm.sender.username}`,
+                    content: dm.text,
+                    time: diffHours < 1 ? 'Just now' :
+                           diffHours < 24 ? `${diffHours}h ago` :
+                           `${Math.floor(diffHours / 24)}d ago`,
+                    timeAgo: diffHours < 1 ? 'Just now' :
+                            diffHours < 24 ? `${diffHours}h ago` :
+                            `${Math.floor(diffHours / 24)}d ago`
+                };
+            });
+        }
+
+        // Render the app
+        const root = ReactDOM.createRoot(document.getElementById('root'));
+        root.render(
+            React.createElement(CardsStreamApp, {
+                title: 'X DMs (Focus)',
+                fetchData: fetchXData,
+                renderContent: renderXContent,
+                platform: 'X (Twitter)'
+            })
+        );
+    </script>
+</body>
+</html>

--- a/cards-stream/iframe/github/index.html
+++ b/cards-stream/iframe/github/index.html
@@ -1,0 +1,195 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>GitHub Issues/PRs - Focus Mode - IFRAME</title>
+    <link rel="stylesheet" href="../../../shared/css/operator.css">
+    <style>
+        .focus-container {
+            flex: 1;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            padding: 2rem;
+        }
+
+        .focus-card {
+            width: 100%;
+            max-width: 900px;
+            height: 80vh;
+            background: var(--surface);
+            border-radius: 1rem;
+            box-shadow: var(--shadow-lg);
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
+        }
+
+        .focus-header {
+            padding: 1.5rem 2rem;
+            background: var(--background);
+            border-bottom: 1px solid var(--border);
+        }
+
+        .focus-header h2 {
+            font-size: 1.5rem;
+            color: var(--text-primary);
+            margin-bottom: 0.5rem;
+        }
+
+        .focus-meta {
+            color: var(--text-secondary);
+            font-size: 0.875rem;
+        }
+
+        iframe {
+            flex: 1;
+            border: none;
+            width: 100%;
+            background: white;
+        }
+
+        .focus-footer {
+            padding: 1.5rem 2rem;
+            background: var(--background);
+            border-top: 1px solid var(--border);
+            display: flex;
+            gap: 1rem;
+        }
+
+        .queue-indicator {
+            position: absolute;
+            top: 1rem;
+            right: 1rem;
+            background: var(--surface);
+            padding: 0.75rem 1.5rem;
+            border-radius: 0.5rem;
+            box-shadow: var(--shadow-lg);
+            font-weight: 600;
+        }
+    </style>
+</head>
+<body>
+    <div class="app">
+        <header class="header">
+            <div class="header-left">
+                <a href="../../.." class="back-link" style="margin-right: 1rem;">← Back to Demos</a>
+                <h1>GitHub Issues & PRs (Focus + Embedded)</h1>
+            </div>
+        </header>
+
+        <div class="main-content">
+            <div class="focus-container">
+                <div class="queue-indicator">
+                    <span id="queue-indicator">Item 1 of 5</span>
+                </div>
+
+                <div class="focus-card">
+                    <div class="focus-header">
+                        <h2 id="current-title">Loading...</h2>
+                        <div class="focus-meta" id="current-meta">Please wait...</div>
+                    </div>
+                    <iframe id="github-iframe" src="about:blank"></iframe>
+                    <div class="focus-footer">
+                        <button class="btn-primary" onclick="handleDone()">
+                            <span>✓</span> DONE
+                        </button>
+                        <button class="btn-secondary" onclick="handleNext()">
+                            <span>→</span> NEXT
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        const githubItems = [
+            {
+                type: 'Issue',
+                number: 1234,
+                title: 'Bug: Login form not responsive on mobile',
+                repo: 'facebook/react',
+                url: 'https://github.com/facebook/react/issues/1234'
+            },
+            {
+                type: 'PR',
+                number: 5678,
+                title: 'Feature: Add dark mode support',
+                repo: 'microsoft/vscode',
+                url: 'https://github.com/microsoft/vscode/pull/5678'
+            },
+            {
+                type: 'Issue',
+                number: 9012,
+                title: 'Performance: Slow API response times',
+                repo: 'vercel/next.js',
+                url: 'https://github.com/vercel/next.js/issues/9012'
+            },
+            {
+                type: 'Issue',
+                number: 3456,
+                title: 'Documentation: Update installation guide',
+                repo: 'nodejs/node',
+                url: 'https://github.com/nodejs/node/issues/3456'
+            },
+            {
+                type: 'PR',
+                number: 7890,
+                title: 'Fix: Security vulnerability in dependencies',
+                repo: 'vuejs/vue',
+                url: 'https://github.com/vuejs/vue/pull/7890'
+            }
+        ];
+
+        let currentIndex = 0;
+
+        function showCurrentItem() {
+            if (githubItems.length === 0) {
+                document.getElementById('current-title').textContent = 'All done!';
+                document.getElementById('current-meta').textContent = 'No more items to process';
+                document.getElementById('github-iframe').src = 'about:blank';
+                return;
+            }
+
+            const item = githubItems[currentIndex];
+            document.getElementById('current-title').textContent = `${item.type} #${item.number}: ${item.title}`;
+            document.getElementById('current-meta').textContent = `Repository: ${item.repo}`;
+            document.getElementById('queue-indicator').textContent = `Item ${currentIndex + 1} of ${githubItems.length}`;
+            document.getElementById('github-iframe').src = item.url;
+        }
+
+        function handleDone() {
+            if (githubItems.length === 0) return;
+            githubItems.splice(currentIndex, 1);
+            if (currentIndex >= githubItems.length && currentIndex > 0) {
+                currentIndex = githubItems.length - 1;
+            }
+            showCurrentItem();
+        }
+
+        function handleNext() {
+            if (githubItems.length === 0) return;
+            const item = githubItems.splice(currentIndex, 1)[0];
+            githubItems.push(item);
+            showCurrentItem();
+        }
+
+        // Keyboard shortcuts
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'd' || e.key === 'D') {
+                e.preventDefault();
+                handleDone();
+            } else if (e.key === 'n' || e.key === 'N' || e.key === 'ArrowRight') {
+                e.preventDefault();
+                handleNext();
+            }
+        });
+
+        // Initial load
+        showCurrentItem();
+    </script>
+</body>
+</html>

--- a/cards-stream/iframe/telegram/index.html
+++ b/cards-stream/iframe/telegram/index.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Telegram Messages - Focus Mode - IFRAME</title>
+    <link rel="stylesheet" href="../../../shared/css/operator.css">
+    <style>
+        .focus-container {
+            flex: 1;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            padding: 2rem;
+        }
+
+        .focus-card {
+            width: 100%;
+            max-width: 900px;
+            height: 80vh;
+            background: var(--surface);
+            border-radius: 1rem;
+            box-shadow: var(--shadow-lg);
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
+        }
+
+        .focus-header {
+            padding: 1.5rem 2rem;
+            background: var(--background);
+            border-bottom: 1px solid var(--border);
+        }
+
+        .focus-header h2 {
+            font-size: 1.5rem;
+            color: var(--text-primary);
+            margin-bottom: 0.5rem;
+        }
+
+        .focus-meta {
+            color: var(--text-secondary);
+            font-size: 0.875rem;
+        }
+
+        iframe {
+            flex: 1;
+            border: none;
+            width: 100%;
+            background: white;
+        }
+
+        .focus-footer {
+            padding: 1.5rem 2rem;
+            background: var(--background);
+            border-top: 1px solid var(--border);
+            display: flex;
+            gap: 1rem;
+        }
+
+        .queue-indicator {
+            position: absolute;
+            top: 1rem;
+            right: 1rem;
+            background: var(--surface);
+            padding: 0.75rem 1.5rem;
+            border-radius: 0.5rem;
+            box-shadow: var(--shadow-lg);
+            font-weight: 600;
+        }
+    </style>
+</head>
+<body>
+    <div class="app">
+        <header class="header">
+            <div class="header-left">
+                <a href="../../.." class="back-link" style="margin-right: 1rem;">← Back to Demos</a>
+                <h1>Telegram Messages (Focus + Embedded)</h1>
+            </div>
+        </header>
+
+        <div class="main-content">
+            <div class="focus-container">
+                <div class="queue-indicator">
+                    <span id="queue-indicator">Item 1 of 8</span>
+                </div>
+
+                <div class="focus-card">
+                    <div class="focus-header">
+                        <h2 id="current-title">Telegram Web</h2>
+                        <div class="focus-meta" id="current-meta">Log in to view your unread messages</div>
+                    </div>
+                    <iframe id="telegram-iframe" src="https://web.telegram.org"></iframe>
+                    <div class="focus-footer">
+                        <button class="btn-primary" onclick="handleDone()">
+                            <span>✓</span> DONE
+                        </button>
+                        <button class="btn-secondary" onclick="handleNext()">
+                            <span>→</span> NEXT
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        const telegramDialogs = [
+            { user: 'Alex Johnson', username: 'alexj', time: '2m ago' },
+            { user: 'Maria Garcia', username: 'mariag', time: '15m ago' },
+            { user: 'John Smith', username: 'johns', time: '1h ago' },
+            { user: 'Sarah Wilson', username: 'sarahw', time: '2h ago' },
+            { user: 'Mike Brown', username: 'mikeb', time: '3h ago' },
+            { user: 'Emma Davis', username: 'emmad', time: '5h ago' },
+            { user: 'David Lee', username: 'davidl', time: '6h ago' },
+            { user: 'Lisa Anderson', username: 'lisaa', time: '8h ago' }
+        ];
+
+        let currentIndex = 0;
+
+        function showCurrentItem() {
+            if (telegramDialogs.length === 0) {
+                document.getElementById('current-title').textContent = 'All done!';
+                document.getElementById('current-meta').textContent = 'No more messages to process';
+                return;
+            }
+
+            const dialog = telegramDialogs[currentIndex];
+            document.getElementById('current-title').textContent = `Chat with ${dialog.user}`;
+            document.getElementById('current-meta').textContent = `@${dialog.username} - ${dialog.time}`;
+            document.getElementById('queue-indicator').textContent = `Item ${currentIndex + 1} of ${telegramDialogs.length}`;
+        }
+
+        function handleDone() {
+            if (telegramDialogs.length === 0) return;
+            telegramDialogs.splice(currentIndex, 1);
+            if (currentIndex >= telegramDialogs.length && currentIndex > 0) {
+                currentIndex = telegramDialogs.length - 1;
+            }
+            showCurrentItem();
+        }
+
+        function handleNext() {
+            if (telegramDialogs.length === 0) return;
+            const item = telegramDialogs.splice(currentIndex, 1)[0];
+            telegramDialogs.push(item);
+            showCurrentItem();
+        }
+
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'd' || e.key === 'D') {
+                e.preventDefault();
+                handleDone();
+            } else if (e.key === 'n' || e.key === 'N' || e.key === 'ArrowRight') {
+                e.preventDefault();
+                handleNext();
+            }
+        });
+
+        showCurrentItem();
+    </script>
+</body>
+</html>

--- a/cards-stream/iframe/vk/index.html
+++ b/cards-stream/iframe/vk/index.html
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>VK Messages - Focus Mode - IFRAME</title>
+    <link rel="stylesheet" href="../../../shared/css/operator.css">
+    <style>
+        .focus-container {
+            flex: 1;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            padding: 2rem;
+        }
+
+        .focus-card {
+            width: 100%;
+            max-width: 900px;
+            height: 80vh;
+            background: var(--surface);
+            border-radius: 1rem;
+            box-shadow: var(--shadow-lg);
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
+        }
+
+        .focus-header {
+            padding: 1.5rem 2rem;
+            background: var(--background);
+            border-bottom: 1px solid var(--border);
+        }
+
+        .focus-header h2 {
+            font-size: 1.5rem;
+            color: var(--text-primary);
+            margin-bottom: 0.5rem;
+        }
+
+        .focus-meta {
+            color: var(--text-secondary);
+            font-size: 0.875rem;
+        }
+
+        iframe {
+            flex: 1;
+            border: none;
+            width: 100%;
+            background: white;
+        }
+
+        .focus-footer {
+            padding: 1.5rem 2rem;
+            background: var(--background);
+            border-top: 1px solid var(--border);
+            display: flex;
+            gap: 1rem;
+        }
+
+        .queue-indicator {
+            position: absolute;
+            top: 1rem;
+            right: 1rem;
+            background: var(--surface);
+            padding: 0.75rem 1.5rem;
+            border-radius: 0.5rem;
+            box-shadow: var(--shadow-lg);
+            font-weight: 600;
+        }
+    </style>
+</head>
+<body>
+    <div class="app">
+        <header class="header">
+            <div class="header-left">
+                <a href="../../.." class="back-link" style="margin-right: 1rem;">← Back to Demos</a>
+                <h1>VK Messages (Focus + Embedded)</h1>
+            </div>
+        </header>
+
+        <div class="main-content">
+            <div class="focus-container">
+                <div class="queue-indicator">
+                    <span id="queue-indicator">Item 1 of 8</span>
+                </div>
+
+                <div class="focus-card">
+                    <div class="focus-header">
+                        <h2 id="current-title">VK Messages</h2>
+                        <div class="focus-meta" id="current-meta">Log in to view your unread messages</div>
+                    </div>
+                    <iframe id="vk-iframe" src="https://vk.com/im"></iframe>
+                    <div class="focus-footer">
+                        <button class="btn-primary" onclick="handleDone()">
+                            <span>✓</span> DONE
+                        </button>
+                        <button class="btn-secondary" onclick="handleNext()">
+                            <span>→</span> NEXT
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        const vkDialogs = [
+            { user: 'Dmitry Ivanov', id: 12345, time: '5m ago' },
+            { user: 'Anna Petrova', id: 23456, time: '20m ago' },
+            { user: 'Pavel Sokolov', id: 34567, time: '1h ago' },
+            { user: 'Olga Smirnova', id: 45678, time: '2h ago' },
+            { user: 'Igor Volkov', id: 56789, time: '4h ago' },
+            { user: 'Natalia Kozlova', id: 67890, time: '5h ago' },
+            { user: 'Sergey Novikov', id: 78901, time: '7h ago' },
+            { user: 'Elena Morozova', id: 89012, time: '9h ago' }
+        ];
+
+        let currentIndex = 0;
+
+        function showCurrentItem() {
+            if (vkDialogs.length === 0) {
+                document.getElementById('current-title').textContent = 'All done!';
+                document.getElementById('current-meta').textContent = 'No more messages to process';
+                return;
+            }
+
+            const dialog = vkDialogs[currentIndex];
+            document.getElementById('current-title').textContent = `Chat with ${dialog.user}`;
+            document.getElementById('current-meta').textContent = `VK ID: ${dialog.id} - ${dialog.time}`;
+            document.getElementById('queue-indicator').textContent = `Item ${currentIndex + 1} of ${vkDialogs.length}`;
+        }
+
+        function handleDone() {
+            if (vkDialogs.length === 0) return;
+            vkDialogs.splice(currentIndex, 1);
+            if (currentIndex >= vkDialogs.length && currentIndex > 0) {
+                currentIndex = vkDialogs.length - 1;
+            }
+            showCurrentItem();
+        }
+
+        function handleNext() {
+            if (vkDialogs.length === 0) return;
+            const item = vkDialogs.splice(currentIndex, 1)[0];
+            vkDialogs.push(item);
+            showCurrentItem();
+        }
+
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'd' || e.key === 'D') {
+                e.preventDefault();
+                handleDone();
+            } else if (e.key === 'n' || e.key === 'N' || e.key === 'ArrowRight') {
+                e.preventDefault();
+                handleNext();
+            }
+        });
+
+        showCurrentItem();
+    </script>
+</body>
+</html>

--- a/cards-stream/iframe/x/index.html
+++ b/cards-stream/iframe/x/index.html
@@ -1,0 +1,162 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>X (Twitter) DMs - Focus Mode - IFRAME</title>
+    <link rel="stylesheet" href="../../../shared/css/operator.css">
+    <style>
+        .focus-container {
+            flex: 1;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+            padding: 2rem;
+        }
+
+        .focus-card {
+            width: 100%;
+            max-width: 900px;
+            height: 80vh;
+            background: var(--surface);
+            border-radius: 1rem;
+            box-shadow: var(--shadow-lg);
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
+        }
+
+        .focus-header {
+            padding: 1.5rem 2rem;
+            background: var(--background);
+            border-bottom: 1px solid var(--border);
+        }
+
+        .focus-header h2 {
+            font-size: 1.5rem;
+            color: var(--text-primary);
+            margin-bottom: 0.5rem;
+        }
+
+        .focus-meta {
+            color: var(--text-secondary);
+            font-size: 0.875rem;
+        }
+
+        iframe {
+            flex: 1;
+            border: none;
+            width: 100%;
+            background: white;
+        }
+
+        .focus-footer {
+            padding: 1.5rem 2rem;
+            background: var(--background);
+            border-top: 1px solid var(--border);
+            display: flex;
+            gap: 1rem;
+        }
+
+        .queue-indicator {
+            position: absolute;
+            top: 1rem;
+            right: 1rem;
+            background: var(--surface);
+            padding: 0.75rem 1.5rem;
+            border-radius: 0.5rem;
+            box-shadow: var(--shadow-lg);
+            font-weight: 600;
+        }
+    </style>
+</head>
+<body>
+    <div class="app">
+        <header class="header">
+            <div class="header-left">
+                <a href="../../.." class="back-link" style="margin-right: 1rem;">← Back to Demos</a>
+                <h1>X Direct Messages (Focus + Embedded)</h1>
+            </div>
+        </header>
+
+        <div class="main-content">
+            <div class="focus-container">
+                <div class="queue-indicator">
+                    <span id="queue-indicator">Item 1 of 6</span>
+                </div>
+
+                <div class="focus-card">
+                    <div class="focus-header">
+                        <h2 id="current-title">X Messages</h2>
+                        <div class="focus-meta" id="current-meta">Log in to view your direct messages</div>
+                    </div>
+                    <iframe id="x-iframe" src="https://twitter.com/messages"></iframe>
+                    <div class="focus-footer">
+                        <button class="btn-primary" onclick="handleDone()">
+                            <span>✓</span> DONE
+                        </button>
+                        <button class="btn-secondary" onclick="handleNext()">
+                            <span>→</span> NEXT
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        const xDMs = [
+            { user: 'Tech Expert', username: 'techexpert', time: '10m ago' },
+            { user: 'Design Pro', username: 'designpro', time: '30m ago' },
+            { user: 'Code Master', username: 'codemaster', time: '1h ago' },
+            { user: 'Data Science', username: 'datascience', time: '3h ago' },
+            { user: 'DevOps', username: 'devops', time: '4h ago' },
+            { user: 'UX Designer', username: 'uxdesigner', time: '6h ago' }
+        ];
+
+        let currentIndex = 0;
+
+        function showCurrentItem() {
+            if (xDMs.length === 0) {
+                document.getElementById('current-title').textContent = 'All done!';
+                document.getElementById('current-meta').textContent = 'No more messages to process';
+                return;
+            }
+
+            const dm = xDMs[currentIndex];
+            document.getElementById('current-title').textContent = `DM with ${dm.user}`;
+            document.getElementById('current-meta').textContent = `@${dm.username} - ${dm.time}`;
+            document.getElementById('queue-indicator').textContent = `Item ${currentIndex + 1} of ${xDMs.length}`;
+        }
+
+        function handleDone() {
+            if (xDMs.length === 0) return;
+            xDMs.splice(currentIndex, 1);
+            if (currentIndex >= xDMs.length && currentIndex > 0) {
+                currentIndex = xDMs.length - 1;
+            }
+            showCurrentItem();
+        }
+
+        function handleNext() {
+            if (xDMs.length === 0) return;
+            const item = xDMs.splice(currentIndex, 1)[0];
+            xDMs.push(item);
+            showCurrentItem();
+        }
+
+        document.addEventListener('keydown', (e) => {
+            if (e.key === 'd' || e.key === 'D') {
+                e.preventDefault();
+                handleDone();
+            } else if (e.key === 'n' || e.key === 'N' || e.key === 'ArrowRight') {
+                e.preventDefault();
+                handleNext();
+            }
+        });
+
+        showCurrentItem();
+    </script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -3,18 +3,416 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Operator - Efficient Decision Making UI</title>
-    <link rel="stylesheet" href="styles.css">
+    <title>Operator - Demo Selection</title>
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
 
-    <!-- React and ReactDOM from CDN -->
-    <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
-    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
-    <!-- Babel Standalone for JSX transformation -->
-    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+        :root {
+            --primary-color: #2563eb;
+            --primary-hover: #1d4ed8;
+            --secondary-color: #64748b;
+            --background: #0f172a;
+            --surface: #1e293b;
+            --border: #334155;
+            --text-primary: #f8fafc;
+            --text-secondary: #94a3b8;
+            --shadow: 0 10px 15px -3px rgb(0 0 0 / 0.3);
+        }
+
+        body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+            background: var(--background);
+            color: var(--text-primary);
+            line-height: 1.6;
+            min-height: 100vh;
+            padding: 2rem;
+        }
+
+        .container {
+            max-width: 1400px;
+            margin: 0 auto;
+        }
+
+        header {
+            text-align: center;
+            margin-bottom: 3rem;
+        }
+
+        h1 {
+            font-size: 3rem;
+            font-weight: 700;
+            color: var(--primary-color);
+            margin-bottom: 1rem;
+        }
+
+        .subtitle {
+            font-size: 1.25rem;
+            color: var(--text-secondary);
+            margin-bottom: 2rem;
+        }
+
+        .description {
+            max-width: 800px;
+            margin: 0 auto 2rem;
+            color: var(--text-secondary);
+            line-height: 1.8;
+        }
+
+        .demo-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(300px, 1fr));
+            gap: 2rem;
+            margin-bottom: 3rem;
+        }
+
+        .section-title {
+            font-size: 2rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+            color: var(--text-primary);
+            border-bottom: 2px solid var(--primary-color);
+            padding-bottom: 0.5rem;
+        }
+
+        .demo-card {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 1rem;
+            padding: 2rem;
+            transition: all 0.3s;
+            cursor: pointer;
+        }
+
+        .demo-card:hover {
+            transform: translateY(-5px);
+            box-shadow: var(--shadow);
+            border-color: var(--primary-color);
+        }
+
+        .demo-card h3 {
+            font-size: 1.5rem;
+            margin-bottom: 0.5rem;
+            color: var(--text-primary);
+        }
+
+        .demo-card .badge {
+            display: inline-block;
+            padding: 0.25rem 0.75rem;
+            border-radius: 0.375rem;
+            font-size: 0.75rem;
+            font-weight: 600;
+            text-transform: uppercase;
+            margin-bottom: 1rem;
+        }
+
+        .badge.api {
+            background: #059669;
+            color: white;
+        }
+
+        .badge.iframe {
+            background: #7c3aed;
+            color: white;
+        }
+
+        .demo-card p {
+            color: var(--text-secondary);
+            margin-bottom: 1rem;
+        }
+
+        .demo-card .platforms {
+            display: flex;
+            gap: 0.5rem;
+            flex-wrap: wrap;
+            margin-top: 1rem;
+        }
+
+        .platform-tag {
+            background: var(--background);
+            padding: 0.5rem 1rem;
+            border-radius: 0.5rem;
+            font-size: 0.875rem;
+            border: 1px solid var(--border);
+        }
+
+        .ui-mode-section {
+            margin-bottom: 4rem;
+        }
+
+        .legend {
+            background: var(--surface);
+            border: 1px solid var(--border);
+            border-radius: 0.5rem;
+            padding: 1.5rem;
+            margin-bottom: 2rem;
+        }
+
+        .legend h4 {
+            margin-bottom: 1rem;
+            color: var(--primary-color);
+        }
+
+        .legend-items {
+            display: flex;
+            gap: 2rem;
+            flex-wrap: wrap;
+        }
+
+        .legend-item {
+            display: flex;
+            align-items: center;
+            gap: 0.5rem;
+        }
+
+        .legend-item .badge {
+            margin: 0;
+        }
+
+        a {
+            text-decoration: none;
+            color: inherit;
+        }
+
+        @media (max-width: 768px) {
+            h1 {
+                font-size: 2rem;
+            }
+
+            .demo-grid {
+                grid-template-columns: 1fr;
+            }
+        }
+    </style>
 </head>
 <body>
-    <div id="root"></div>
+    <div class="container">
+        <header>
+            <h1>Operator</h1>
+            <p class="subtitle">Queue-based Decision Making UI</p>
+            <div class="description">
+                <p>Choose from various demo configurations to see how Operator handles different platforms and integration methods. Each demo focuses on processing unread messages and unprocessed items efficiently.</p>
+            </div>
+        </header>
 
-    <script type="text/babel" src="app.js"></script>
+        <div class="legend">
+            <h4>Integration Types</h4>
+            <div class="legend-items">
+                <div class="legend-item">
+                    <span class="badge api">API</span>
+                    <span>Direct API integration with browser authentication</span>
+                </div>
+                <div class="legend-item">
+                    <span class="badge iframe">IFRAME</span>
+                    <span>Embedded web interface version</span>
+                </div>
+            </div>
+        </div>
+
+        <!-- List + Sidebar Mode -->
+        <div class="ui-mode-section">
+            <h2 class="section-title">List + Sidebar Mode</h2>
+            <p style="color: var(--text-secondary); margin-bottom: 1.5rem;">View all items in a sidebar list while working on the selected item in the main area.</p>
+
+            <div class="demo-grid">
+                <a href="list-sidebar/api/github/index.html">
+                    <div class="demo-card">
+                        <h3>GitHub Issues/PRs</h3>
+                        <span class="badge api">API</span>
+                        <p>Process unprocessed GitHub issues and pull requests with OAuth authentication.</p>
+                        <div class="platforms">
+                            <span class="platform-tag">GitHub OAuth</span>
+                            <span class="platform-tag">Issues</span>
+                            <span class="platform-tag">Pull Requests</span>
+                        </div>
+                    </div>
+                </a>
+
+                <a href="list-sidebar/api/telegram/index.html">
+                    <div class="demo-card">
+                        <h3>Telegram Messages</h3>
+                        <span class="badge api">API</span>
+                        <p>Handle unread private messages from Telegram with API authentication.</p>
+                        <div class="platforms">
+                            <span class="platform-tag">Telegram API</span>
+                            <span class="platform-tag">Private Messages</span>
+                        </div>
+                    </div>
+                </a>
+
+                <a href="list-sidebar/api/vk/index.html">
+                    <div class="demo-card">
+                        <h3>VK Messages</h3>
+                        <span class="badge api">API</span>
+                        <p>Process unread VK private messages with VK API authentication.</p>
+                        <div class="platforms">
+                            <span class="platform-tag">VK API</span>
+                            <span class="platform-tag">Private Messages</span>
+                        </div>
+                    </div>
+                </a>
+
+                <a href="list-sidebar/api/x/index.html">
+                    <div class="demo-card">
+                        <h3>X (Twitter) DMs</h3>
+                        <span class="badge api">API</span>
+                        <p>Manage unread direct messages from X with OAuth authentication.</p>
+                        <div class="platforms">
+                            <span class="platform-tag">X OAuth</span>
+                            <span class="platform-tag">Direct Messages</span>
+                        </div>
+                    </div>
+                </a>
+
+                <a href="list-sidebar/iframe/github/index.html">
+                    <div class="demo-card">
+                        <h3>GitHub Issues/PRs</h3>
+                        <span class="badge iframe">IFRAME</span>
+                        <p>Embedded GitHub interface for processing issues and pull requests.</p>
+                        <div class="platforms">
+                            <span class="platform-tag">Embedded</span>
+                        </div>
+                    </div>
+                </a>
+
+                <a href="list-sidebar/iframe/telegram/index.html">
+                    <div class="demo-card">
+                        <h3>Telegram Messages</h3>
+                        <span class="badge iframe">IFRAME</span>
+                        <p>Embedded Telegram Web interface for private messages.</p>
+                        <div class="platforms">
+                            <span class="platform-tag">Embedded</span>
+                        </div>
+                    </div>
+                </a>
+
+                <a href="list-sidebar/iframe/vk/index.html">
+                    <div class="demo-card">
+                        <h3>VK Messages</h3>
+                        <span class="badge iframe">IFRAME</span>
+                        <p>Embedded VK interface for processing private messages.</p>
+                        <div class="platforms">
+                            <span class="platform-tag">Embedded</span>
+                        </div>
+                    </div>
+                </a>
+
+                <a href="list-sidebar/iframe/x/index.html">
+                    <div class="demo-card">
+                        <h3>X (Twitter) DMs</h3>
+                        <span class="badge iframe">IFRAME</span>
+                        <p>Embedded X interface for managing direct messages.</p>
+                        <div class="platforms">
+                            <span class="platform-tag">Embedded</span>
+                        </div>
+                    </div>
+                </a>
+            </div>
+        </div>
+
+        <!-- Cards Stream (Focus) Mode -->
+        <div class="ui-mode-section">
+            <h2 class="section-title">Cards Stream (Focus) Mode</h2>
+            <p style="color: var(--text-secondary); margin-bottom: 1.5rem;">See one card at a time for maximum focus. Perfect for rapid decision making.</p>
+
+            <div class="demo-grid">
+                <a href="cards-stream/api/github/index.html">
+                    <div class="demo-card">
+                        <h3>GitHub Issues/PRs</h3>
+                        <span class="badge api">API</span>
+                        <p>Process unprocessed GitHub issues and pull requests with OAuth authentication.</p>
+                        <div class="platforms">
+                            <span class="platform-tag">GitHub OAuth</span>
+                            <span class="platform-tag">Issues</span>
+                            <span class="platform-tag">Pull Requests</span>
+                        </div>
+                    </div>
+                </a>
+
+                <a href="cards-stream/api/telegram/index.html">
+                    <div class="demo-card">
+                        <h3>Telegram Messages</h3>
+                        <span class="badge api">API</span>
+                        <p>Handle unread private messages from Telegram with API authentication.</p>
+                        <div class="platforms">
+                            <span class="platform-tag">Telegram API</span>
+                            <span class="platform-tag">Private Messages</span>
+                        </div>
+                    </div>
+                </a>
+
+                <a href="cards-stream/api/vk/index.html">
+                    <div class="demo-card">
+                        <h3>VK Messages</h3>
+                        <span class="badge api">API</span>
+                        <p>Process unread VK private messages with VK API authentication.</p>
+                        <div class="platforms">
+                            <span class="platform-tag">VK API</span>
+                            <span class="platform-tag">Private Messages</span>
+                        </div>
+                    </div>
+                </a>
+
+                <a href="cards-stream/api/x/index.html">
+                    <div class="demo-card">
+                        <h3>X (Twitter) DMs</h3>
+                        <span class="badge api">API</span>
+                        <p>Manage unread direct messages from X with OAuth authentication.</p>
+                        <div class="platforms">
+                            <span class="platform-tag">X OAuth</span>
+                            <span class="platform-tag">Direct Messages</span>
+                        </div>
+                    </div>
+                </a>
+
+                <a href="cards-stream/iframe/github/index.html">
+                    <div class="demo-card">
+                        <h3>GitHub Issues/PRs</h3>
+                        <span class="badge iframe">IFRAME</span>
+                        <p>Embedded GitHub interface for processing issues and pull requests.</p>
+                        <div class="platforms">
+                            <span class="platform-tag">Embedded</span>
+                        </div>
+                    </div>
+                </a>
+
+                <a href="cards-stream/iframe/telegram/index.html">
+                    <div class="demo-card">
+                        <h3>Telegram Messages</h3>
+                        <span class="badge iframe">IFRAME</span>
+                        <p>Embedded Telegram Web interface for private messages.</p>
+                        <div class="platforms">
+                            <span class="platform-tag">Embedded</span>
+                        </div>
+                    </div>
+                </a>
+
+                <a href="cards-stream/iframe/vk/index.html">
+                    <div class="demo-card">
+                        <h3>VK Messages</h3>
+                        <span class="badge iframe">IFRAME</span>
+                        <p>Embedded VK interface for processing private messages.</p>
+                        <div class="platforms">
+                            <span class="platform-tag">Embedded</span>
+                        </div>
+                    </div>
+                </a>
+
+                <a href="cards-stream/iframe/x/index.html">
+                    <div class="demo-card">
+                        <h3>X (Twitter) DMs</h3>
+                        <span class="badge iframe">IFRAME</span>
+                        <p>Embedded X interface for managing direct messages.</p>
+                        <div class="platforms">
+                            <span class="platform-tag">Embedded</span>
+                        </div>
+                    </div>
+                </a>
+            </div>
+        </div>
+    </div>
 </body>
 </html>

--- a/list-sidebar/api/github/index.html
+++ b/list-sidebar/api/github/index.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>GitHub Issues/PRs - List + Sidebar - API</title>
+    <link rel="stylesheet" href="../../../shared/css/operator.css">
+
+    <!-- React and ReactDOM from CDN -->
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+    <!-- Babel Standalone for JSX transformation -->
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+</head>
+<body>
+    <div id="root"></div>
+
+    <script src="../../../shared/js/auth-utils.js"></script>
+    <script src="../../../shared/js/ui-components.js"></script>
+    <script type="text/babel">
+        const { useState } = React;
+
+        // Custom content renderer for GitHub issues/PRs
+        function renderGitHubContent(item) {
+            return React.createElement('div', null,
+                React.createElement('div', { className: 'card-content' }, item.body),
+                item.labels && item.labels.length > 0 &&
+                    React.createElement('div', { className: 'issue-labels' },
+                        item.labels.map((label, idx) =>
+                            React.createElement('span', {
+                                key: idx,
+                                className: `label ${label}`
+                            }, label)
+                        )
+                    ),
+                React.createElement('div', { className: 'user-info' },
+                    React.createElement('img', {
+                        src: item.user.avatar_url,
+                        alt: item.user.login,
+                        className: 'user-avatar'
+                    }),
+                    React.createElement('div', null,
+                        React.createElement('div', { className: 'user-name' }, item.user.login),
+                        React.createElement('div', {
+                            style: { fontSize: '0.875rem', color: 'var(--text-secondary)' }
+                        }, `#${item.number}`)
+                    )
+                )
+            );
+        }
+
+        // Fetch GitHub data (using mock data for demo)
+        async function fetchGitHubData() {
+            // Simulate API call delay
+            await new Promise(resolve => setTimeout(resolve, 1000));
+
+            // In a real app, you would:
+            // 1. Check for authentication token
+            // 2. Make API call to GitHub
+            // const token = new AuthManager('github').getToken();
+            // const response = await fetch('https://api.github.com/repos/OWNER/REPO/issues', {
+            //     headers: { Authorization: `token ${token}` }
+            // });
+
+            // For demo, use mock data
+            const issues = MockDataGenerators.github.generateIssues(5);
+            const prs = MockDataGenerators.github.generatePullRequests(3);
+
+            // Combine and format data
+            const combined = [...issues, ...prs].map(item => {
+                const timeAgo = new Date(item.created_at);
+                const now = new Date();
+                const diffHours = Math.floor((now - timeAgo) / (1000 * 60 * 60));
+
+                return {
+                    ...item,
+                    source: item.pull_request ? 'Pull Request' : 'Issue',
+                    type: item.pull_request ? 'Pull Request' : 'Issue',
+                    title: item.title,
+                    content: item.body,
+                    time: diffHours < 1 ? 'Just now' :
+                           diffHours < 24 ? `${diffHours}h ago` :
+                           `${Math.floor(diffHours / 24)}d ago`,
+                    timeAgo: diffHours < 1 ? 'Just now' :
+                            diffHours < 24 ? `${diffHours}h ago` :
+                            `${Math.floor(diffHours / 24)}d ago`
+                };
+            });
+
+            return combined;
+        }
+
+        // Render the app
+        const root = ReactDOM.createRoot(document.getElementById('root'));
+        root.render(
+            React.createElement(ListSidebarApp, {
+                title: 'GitHub Issues & Pull Requests',
+                fetchData: fetchGitHubData,
+                renderContent: renderGitHubContent,
+                platform: 'GitHub'
+            })
+        );
+    </script>
+</body>
+</html>

--- a/list-sidebar/api/telegram/index.html
+++ b/list-sidebar/api/telegram/index.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Telegram Messages - List + Sidebar - API</title>
+    <link rel="stylesheet" href="../../../shared/css/operator.css">
+
+    <!-- React and ReactDOM from CDN -->
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+    <!-- Babel Standalone for JSX transformation -->
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+</head>
+<body>
+    <div id="root"></div>
+
+    <script src="../../../shared/js/auth-utils.js"></script>
+    <script src="../../../shared/js/ui-components.js"></script>
+    <script type="text/babel">
+        const { useState } = React;
+
+        // Custom content renderer for Telegram messages
+        function renderTelegramContent(item) {
+            return React.createElement('div', null,
+                React.createElement('div', { className: 'message-content' }, item.text),
+                React.createElement('div', { className: 'message-meta' },
+                    React.createElement('div', null,
+                        React.createElement('strong', null, 'From: '),
+                        item.from.first_name,
+                        ' (@', item.from.username, ')'
+                    ),
+                    React.createElement('div', null,
+                        React.createElement('span', {
+                            style: {
+                                background: '#10b981',
+                                padding: '0.25rem 0.5rem',
+                                borderRadius: '0.25rem',
+                                fontSize: '0.75rem',
+                                color: 'white'
+                            }
+                        }, 'UNREAD')
+                    )
+                )
+            );
+        }
+
+        // Fetch Telegram data (using mock data for demo)
+        async function fetchTelegramData() {
+            // Simulate API call delay
+            await new Promise(resolve => setTimeout(resolve, 1000));
+
+            // In a real app, you would:
+            // 1. Authenticate with Telegram API
+            // 2. Fetch unread messages
+            // const messages = await telegramClient.getUnreadMessages();
+
+            // For demo, use mock data
+            const messages = MockDataGenerators.telegram.generateMessages(8);
+
+            // Format data
+            return messages.map(msg => {
+                const timeAgo = Date.now() / 1000 - msg.date;
+                const hours = Math.floor(timeAgo / 3600);
+
+                return {
+                    ...msg,
+                    source: 'Telegram',
+                    type: 'Private Message',
+                    title: `Message from ${msg.from.first_name}`,
+                    content: msg.text,
+                    time: hours < 1 ? 'Just now' :
+                           hours < 24 ? `${hours}h ago` :
+                           `${Math.floor(hours / 24)}d ago`,
+                    timeAgo: hours < 1 ? 'Just now' :
+                            hours < 24 ? `${hours}h ago` :
+                            `${Math.floor(hours / 24)}d ago`
+                };
+            });
+        }
+
+        // Render the app
+        const root = ReactDOM.createRoot(document.getElementById('root'));
+        root.render(
+            React.createElement(ListSidebarApp, {
+                title: 'Telegram Private Messages',
+                fetchData: fetchTelegramData,
+                renderContent: renderTelegramContent,
+                platform: 'Telegram'
+            })
+        );
+    </script>
+</body>
+</html>

--- a/list-sidebar/api/vk/index.html
+++ b/list-sidebar/api/vk/index.html
@@ -1,0 +1,94 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>VK Messages - List + Sidebar - API</title>
+    <link rel="stylesheet" href="../../../shared/css/operator.css">
+
+    <!-- React and ReactDOM from CDN -->
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+    <!-- Babel Standalone for JSX transformation -->
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+</head>
+<body>
+    <div id="root"></div>
+
+    <script src="../../../shared/js/auth-utils.js"></script>
+    <script src="../../../shared/js/ui-components.js"></script>
+    <script type="text/babel">
+        const { useState } = React;
+
+        // Custom content renderer for VK messages
+        function renderVKContent(item) {
+            return React.createElement('div', null,
+                React.createElement('div', { className: 'message-content' }, item.text),
+                React.createElement('div', { className: 'message-meta' },
+                    React.createElement('div', null,
+                        React.createElement('strong', null, 'From: '),
+                        item.first_name,
+                        ' (ID: ', item.user_id, ')'
+                    ),
+                    React.createElement('div', null,
+                        React.createElement('span', {
+                            style: {
+                                background: '#07f',
+                                padding: '0.25rem 0.5rem',
+                                borderRadius: '0.25rem',
+                                fontSize: '0.75rem',
+                                color: 'white'
+                            }
+                        }, 'UNREAD')
+                    )
+                )
+            );
+        }
+
+        // Fetch VK data (using mock data for demo)
+        async function fetchVKData() {
+            // Simulate API call delay
+            await new Promise(resolve => setTimeout(resolve, 1000));
+
+            // In a real app, you would:
+            // 1. Authenticate with VK API
+            // 2. Fetch unread messages
+            // const response = await fetch(`https://api.vk.com/method/messages.get?filter=1&access_token=${token}&v=5.131`);
+
+            // For demo, use mock data
+            const messages = MockDataGenerators.vk.generateMessages(8);
+
+            // Format data
+            return messages.map(msg => {
+                const timeAgo = Date.now() / 1000 - msg.date;
+                const hours = Math.floor(timeAgo / 3600);
+
+                return {
+                    ...msg,
+                    source: 'VK',
+                    type: 'Private Message',
+                    title: `Message from ${msg.first_name}`,
+                    content: msg.text,
+                    time: hours < 1 ? 'Just now' :
+                           hours < 24 ? `${hours}h ago` :
+                           `${Math.floor(hours / 24)}d ago`,
+                    timeAgo: hours < 1 ? 'Just now' :
+                            hours < 24 ? `${hours}h ago` :
+                            `${Math.floor(hours / 24)}d ago`
+                };
+            });
+        }
+
+        // Render the app
+        const root = ReactDOM.createRoot(document.getElementById('root'));
+        root.render(
+            React.createElement(ListSidebarApp, {
+                title: 'VK Private Messages',
+                fetchData: fetchVKData,
+                renderContent: renderVKContent,
+                platform: 'VK'
+            })
+        );
+    </script>
+</body>
+</html>

--- a/list-sidebar/api/x/index.html
+++ b/list-sidebar/api/x/index.html
@@ -1,0 +1,105 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>X (Twitter) DMs - List + Sidebar - API</title>
+    <link rel="stylesheet" href="../../../shared/css/operator.css">
+
+    <!-- React and ReactDOM from CDN -->
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.production.min.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.production.min.js"></script>
+    <!-- Babel Standalone for JSX transformation -->
+    <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+</head>
+<body>
+    <div id="root"></div>
+
+    <script src="../../../shared/js/auth-utils.js"></script>
+    <script src="../../../shared/js/ui-components.js"></script>
+    <script type="text/babel">
+        const { useState } = React;
+
+        // Custom content renderer for X DMs
+        function renderXContent(item) {
+            return React.createElement('div', null,
+                React.createElement('div', { className: 'message-content' }, item.text),
+                React.createElement('div', { className: 'user-info' },
+                    React.createElement('img', {
+                        src: item.sender.profile_image_url,
+                        alt: item.sender.username,
+                        className: 'user-avatar'
+                    }),
+                    React.createElement('div', null,
+                        React.createElement('div', { className: 'user-name' },
+                            item.sender.name,
+                            ' (@', item.sender.username, ')'
+                        ),
+                        React.createElement('div', {
+                            style: { fontSize: '0.875rem', color: 'var(--text-secondary)' }
+                        },
+                            React.createElement('span', {
+                                style: {
+                                    background: '#1d9bf0',
+                                    padding: '0.25rem 0.5rem',
+                                    borderRadius: '0.25rem',
+                                    fontSize: '0.75rem',
+                                    color: 'white'
+                                }
+                            }, 'UNREAD')
+                        )
+                    )
+                )
+            );
+        }
+
+        // Fetch X (Twitter) data (using mock data for demo)
+        async function fetchXData() {
+            // Simulate API call delay
+            await new Promise(resolve => setTimeout(resolve, 1000));
+
+            // In a real app, you would:
+            // 1. Authenticate with X API v2
+            // 2. Fetch unread DMs
+            // const response = await fetch('https://api.twitter.com/2/dm_conversations/with/:participant_id/dm_events', {
+            //     headers: { Authorization: `Bearer ${token}` }
+            // });
+
+            // For demo, use mock data
+            const dms = MockDataGenerators.x.generateDMs(6);
+
+            // Format data
+            return dms.map(dm => {
+                const timeAgo = new Date(dm.created_at);
+                const now = new Date();
+                const diffHours = Math.floor((now - timeAgo) / (1000 * 60 * 60));
+
+                return {
+                    ...dm,
+                    source: 'X (Twitter)',
+                    type: 'Direct Message',
+                    title: `DM from @${dm.sender.username}`,
+                    content: dm.text,
+                    time: diffHours < 1 ? 'Just now' :
+                           diffHours < 24 ? `${diffHours}h ago` :
+                           `${Math.floor(diffHours / 24)}d ago`,
+                    timeAgo: diffHours < 1 ? 'Just now' :
+                            diffHours < 24 ? `${diffHours}h ago` :
+                            `${Math.floor(diffHours / 24)}d ago`
+                };
+            });
+        }
+
+        // Render the app
+        const root = ReactDOM.createRoot(document.getElementById('root'));
+        root.render(
+            React.createElement(ListSidebarApp, {
+                title: 'X Direct Messages',
+                fetchData: fetchXData,
+                renderContent: renderXContent,
+                platform: 'X (Twitter)'
+            })
+        );
+    </script>
+</body>
+</html>

--- a/list-sidebar/iframe/github/index.html
+++ b/list-sidebar/iframe/github/index.html
@@ -1,0 +1,161 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>GitHub Issues/PRs - List + Sidebar - IFRAME</title>
+    <link rel="stylesheet" href="../../../shared/css/operator.css">
+    <style>
+        .iframe-container {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
+        }
+
+        .iframe-header {
+            padding: 1rem 2rem;
+            background: var(--surface);
+            border-bottom: 1px solid var(--border);
+        }
+
+        .iframe-header h2 {
+            font-size: 1.25rem;
+            color: var(--text-primary);
+        }
+
+        .current-item-info {
+            margin-top: 0.5rem;
+            color: var(--text-secondary);
+            font-size: 0.875rem;
+        }
+
+        iframe {
+            flex: 1;
+            border: none;
+            width: 100%;
+            background: white;
+        }
+
+        .sidebar {
+            width: 300px;
+        }
+    </style>
+</head>
+<body>
+    <div class="app">
+        <header class="header">
+            <div class="header-left">
+                <a href="../../.." class="back-link" style="margin-right: 1rem;">← Back to Demos</a>
+                <h1>GitHub Issues & PRs (Embedded)</h1>
+            </div>
+            <div class="controls">
+                <div class="queue-info">
+                    <span class="queue-count">Queue: <span id="queue-count">0</span></span>
+                </div>
+            </div>
+        </header>
+
+        <div class="main-content">
+            <aside class="sidebar active">
+                <div class="sidebar-header">
+                    <h2>Unprocessed Items</h2>
+                </div>
+                <div class="card-list" id="item-list"></div>
+            </aside>
+
+            <div class="iframe-container">
+                <div class="iframe-header">
+                    <h2 id="current-item-title">Select an item from the list</h2>
+                    <div class="current-item-info" id="current-item-info">
+                        Click on an issue or pull request to view it
+                    </div>
+                </div>
+                <iframe id="github-iframe" src="about:blank"></iframe>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        // Sample GitHub items (in a real app, fetch from GitHub API)
+        const githubItems = [
+            {
+                type: 'Issue',
+                number: 1234,
+                title: 'Bug: Login form not responsive on mobile',
+                repo: 'facebook/react',
+                url: 'https://github.com/facebook/react/issues/1234'
+            },
+            {
+                type: 'PR',
+                number: 5678,
+                title: 'Feature: Add dark mode support',
+                repo: 'microsoft/vscode',
+                url: 'https://github.com/microsoft/vscode/pull/5678'
+            },
+            {
+                type: 'Issue',
+                number: 9012,
+                title: 'Performance: Slow API response times',
+                repo: 'vercel/next.js',
+                url: 'https://github.com/vercel/next.js/issues/9012'
+            },
+            {
+                type: 'Issue',
+                number: 3456,
+                title: 'Documentation: Update installation guide',
+                repo: 'nodejs/node',
+                url: 'https://github.com/nodejs/node/issues/3456'
+            },
+            {
+                type: 'PR',
+                number: 7890,
+                title: 'Fix: Security vulnerability in dependencies',
+                repo: 'vuejs/vue',
+                url: 'https://github.com/vuejs/vue/pull/7890'
+            }
+        ];
+
+        let currentIndex = -1;
+
+        function renderList() {
+            const listContainer = document.getElementById('item-list');
+            listContainer.innerHTML = '';
+
+            githubItems.forEach((item, index) => {
+                const itemEl = document.createElement('div');
+                itemEl.className = `list-item ${index === currentIndex ? 'active' : ''}`;
+                itemEl.innerHTML = `
+                    <div class="list-item-header">
+                        <div class="list-item-source">${item.type}</div>
+                        <div class="list-item-time">#${item.number}</div>
+                    </div>
+                    <div class="list-item-title">${item.title}</div>
+                    <div class="list-item-preview">${item.repo}</div>
+                `;
+                itemEl.onclick = () => selectItem(index);
+                listContainer.appendChild(itemEl);
+            });
+
+            document.getElementById('queue-count').textContent = githubItems.length;
+        }
+
+        function selectItem(index) {
+            currentIndex = index;
+            const item = githubItems[index];
+
+            document.getElementById('current-item-title').textContent = `${item.type} #${item.number}: ${item.title}`;
+            document.getElementById('current-item-info').textContent = `Repository: ${item.repo}`;
+            document.getElementById('github-iframe').src = item.url;
+
+            renderList();
+        }
+
+        // Initial render
+        renderList();
+
+        // Note: Many sites prevent iframe embedding via X-Frame-Options header
+        // In a real app, you might need to use a proxy or API integration instead
+    </script>
+</body>
+</html>

--- a/list-sidebar/iframe/telegram/index.html
+++ b/list-sidebar/iframe/telegram/index.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Telegram Messages - List + Sidebar - IFRAME</title>
+    <link rel="stylesheet" href="../../../shared/css/operator.css">
+    <style>
+        .iframe-container {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
+        }
+
+        .iframe-header {
+            padding: 1rem 2rem;
+            background: var(--surface);
+            border-bottom: 1px solid var(--border);
+        }
+
+        .iframe-header h2 {
+            font-size: 1.25rem;
+            color: var(--text-primary);
+        }
+
+        .current-item-info {
+            margin-top: 0.5rem;
+            color: var(--text-secondary);
+            font-size: 0.875rem;
+        }
+
+        iframe {
+            flex: 1;
+            border: none;
+            width: 100%;
+            background: white;
+        }
+
+        .sidebar {
+            width: 300px;
+        }
+    </style>
+</head>
+<body>
+    <div class="app">
+        <header class="header">
+            <div class="header-left">
+                <a href="../../.." class="back-link" style="margin-right: 1rem;">← Back to Demos</a>
+                <h1>Telegram Messages (Embedded)</h1>
+            </div>
+            <div class="controls">
+                <div class="queue-info">
+                    <span class="queue-count">Queue: <span id="queue-count">0</span></span>
+                </div>
+            </div>
+        </header>
+
+        <div class="main-content">
+            <aside class="sidebar active">
+                <div class="sidebar-header">
+                    <h2>Unread Dialogs</h2>
+                </div>
+                <div class="card-list" id="item-list"></div>
+            </aside>
+
+            <div class="iframe-container">
+                <div class="iframe-header">
+                    <h2 id="current-item-title">Telegram Web</h2>
+                    <div class="current-item-info" id="current-item-info">
+                        Embedded Telegram Web interface - log in to access your messages
+                    </div>
+                </div>
+                <iframe id="telegram-iframe" src="https://web.telegram.org"></iframe>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        // Sample Telegram dialogs (in a real app, fetch from Telegram API)
+        const telegramDialogs = [
+            { user: 'Alex Johnson', username: 'alexj', preview: 'Hey! Did you see the presentation...', time: '2m ago' },
+            { user: 'Maria Garcia', username: 'mariag', preview: 'Can we schedule a meeting for...', time: '15m ago' },
+            { user: 'John Smith', username: 'johns', preview: 'The project deadline has been...', time: '1h ago' },
+            { user: 'Sarah Wilson', username: 'sarahw', preview: 'I have a quick question about...', time: '2h ago' },
+            { user: 'Mike Brown', username: 'mikeb', preview: 'Thanks for your help with the...', time: '3h ago' },
+            { user: 'Emma Davis', username: 'emmad', preview: 'Are you available for a quick...', time: '5h ago' },
+            { user: 'David Lee', username: 'davidl', preview: 'I sent you the updated design...', time: '6h ago' },
+            { user: 'Lisa Anderson', username: 'lisaa', preview: 'Let me know if you need any...', time: '8h ago' }
+        ];
+
+        let currentIndex = -1;
+
+        function renderList() {
+            const listContainer = document.getElementById('item-list');
+            listContainer.innerHTML = '';
+
+            telegramDialogs.forEach((dialog, index) => {
+                const itemEl = document.createElement('div');
+                itemEl.className = `list-item ${index === currentIndex ? 'active' : ''}`;
+                itemEl.innerHTML = `
+                    <div class="list-item-header">
+                        <div class="list-item-source">@${dialog.username}</div>
+                        <div class="list-item-time">${dialog.time}</div>
+                    </div>
+                    <div class="list-item-title">${dialog.user}</div>
+                    <div class="list-item-preview">${dialog.preview}</div>
+                `;
+                itemEl.onclick = () => selectItem(index);
+                listContainer.appendChild(itemEl);
+            });
+
+            document.getElementById('queue-count').textContent = telegramDialogs.length;
+        }
+
+        function selectItem(index) {
+            currentIndex = index;
+            const dialog = telegramDialogs[index];
+
+            document.getElementById('current-item-title').textContent = `Chat with ${dialog.user}`;
+            document.getElementById('current-item-info').textContent = `@${dialog.username} - ${dialog.time}`;
+
+            renderList();
+        }
+
+        // Initial render
+        renderList();
+    </script>
+</body>
+</html>

--- a/list-sidebar/iframe/vk/index.html
+++ b/list-sidebar/iframe/vk/index.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>VK Messages - List + Sidebar - IFRAME</title>
+    <link rel="stylesheet" href="../../../shared/css/operator.css">
+    <style>
+        .iframe-container {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
+        }
+
+        .iframe-header {
+            padding: 1rem 2rem;
+            background: var(--surface);
+            border-bottom: 1px solid var(--border);
+        }
+
+        .iframe-header h2 {
+            font-size: 1.25rem;
+            color: var(--text-primary);
+        }
+
+        .current-item-info {
+            margin-top: 0.5rem;
+            color: var(--text-secondary);
+            font-size: 0.875rem;
+        }
+
+        iframe {
+            flex: 1;
+            border: none;
+            width: 100%;
+            background: white;
+        }
+
+        .sidebar {
+            width: 300px;
+        }
+    </style>
+</head>
+<body>
+    <div class="app">
+        <header class="header">
+            <div class="header-left">
+                <a href="../../.." class="back-link" style="margin-right: 1rem;">← Back to Demos</a>
+                <h1>VK Messages (Embedded)</h1>
+            </div>
+            <div class="controls">
+                <div class="queue-info">
+                    <span class="queue-count">Queue: <span id="queue-count">0</span></span>
+                </div>
+            </div>
+        </header>
+
+        <div class="main-content">
+            <aside class="sidebar active">
+                <div class="sidebar-header">
+                    <h2>Unread Messages</h2>
+                </div>
+                <div class="card-list" id="item-list"></div>
+            </aside>
+
+            <div class="iframe-container">
+                <div class="iframe-header">
+                    <h2 id="current-item-title">VK Messages</h2>
+                    <div class="current-item-info" id="current-item-info">
+                        Embedded VK interface - log in to access your messages
+                    </div>
+                </div>
+                <iframe id="vk-iframe" src="https://vk.com/im"></iframe>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        // Sample VK dialogs (in a real app, fetch from VK API)
+        const vkDialogs = [
+            { user: 'Dmitry Ivanov', id: 12345, preview: 'Привет! Как дела?', time: '5m ago' },
+            { user: 'Anna Petrova', id: 23456, preview: 'Ты видел новости о проекте?', time: '20m ago' },
+            { user: 'Pavel Sokolov', id: 34567, preview: 'Давай встретимся завтра?', time: '1h ago' },
+            { user: 'Olga Smirnova', id: 45678, preview: 'Отправил тебе документы.', time: '2h ago' },
+            { user: 'Igor Volkov', id: 56789, preview: 'Спасибо за помощь!', time: '4h ago' },
+            { user: 'Natalia Kozlova', id: 67890, preview: 'Можешь позвонить?', time: '5h ago' },
+            { user: 'Sergey Novikov', id: 78901, preview: 'Нужна твоя консультация.', time: '7h ago' },
+            { user: 'Elena Morozova', id: 89012, preview: 'Всё готово к презентации.', time: '9h ago' }
+        ];
+
+        let currentIndex = -1;
+
+        function renderList() {
+            const listContainer = document.getElementById('item-list');
+            listContainer.innerHTML = '';
+
+            vkDialogs.forEach((dialog, index) => {
+                const itemEl = document.createElement('div');
+                itemEl.className = `list-item ${index === currentIndex ? 'active' : ''}`;
+                itemEl.innerHTML = `
+                    <div class="list-item-header">
+                        <div class="list-item-source">ID: ${dialog.id}</div>
+                        <div class="list-item-time">${dialog.time}</div>
+                    </div>
+                    <div class="list-item-title">${dialog.user}</div>
+                    <div class="list-item-preview">${dialog.preview}</div>
+                `;
+                itemEl.onclick = () => selectItem(index);
+                listContainer.appendChild(itemEl);
+            });
+
+            document.getElementById('queue-count').textContent = vkDialogs.length;
+        }
+
+        function selectItem(index) {
+            currentIndex = index;
+            const dialog = vkDialogs[index];
+
+            document.getElementById('current-item-title').textContent = `Chat with ${dialog.user}`;
+            document.getElementById('current-item-info').textContent = `VK ID: ${dialog.id} - ${dialog.time}`;
+
+            renderList();
+        }
+
+        // Initial render
+        renderList();
+    </script>
+</body>
+</html>

--- a/list-sidebar/iframe/x/index.html
+++ b/list-sidebar/iframe/x/index.html
@@ -1,0 +1,128 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>X (Twitter) DMs - List + Sidebar - IFRAME</title>
+    <link rel="stylesheet" href="../../../shared/css/operator.css">
+    <style>
+        .iframe-container {
+            flex: 1;
+            display: flex;
+            flex-direction: column;
+            overflow: hidden;
+        }
+
+        .iframe-header {
+            padding: 1rem 2rem;
+            background: var(--surface);
+            border-bottom: 1px solid var(--border);
+        }
+
+        .iframe-header h2 {
+            font-size: 1.25rem;
+            color: var(--text-primary);
+        }
+
+        .current-item-info {
+            margin-top: 0.5rem;
+            color: var(--text-secondary);
+            font-size: 0.875rem;
+        }
+
+        iframe {
+            flex: 1;
+            border: none;
+            width: 100%;
+            background: white;
+        }
+
+        .sidebar {
+            width: 300px;
+        }
+    </style>
+</head>
+<body>
+    <div class="app">
+        <header class="header">
+            <div class="header-left">
+                <a href="../../.." class="back-link" style="margin-right: 1rem;">← Back to Demos</a>
+                <h1>X Direct Messages (Embedded)</h1>
+            </div>
+            <div class="controls">
+                <div class="queue-info">
+                    <span class="queue-count">Queue: <span id="queue-count">0</span></span>
+                </div>
+            </div>
+        </header>
+
+        <div class="main-content">
+            <aside class="sidebar active">
+                <div class="sidebar-header">
+                    <h2>Unread DMs</h2>
+                </div>
+                <div class="card-list" id="item-list"></div>
+            </aside>
+
+            <div class="iframe-container">
+                <div class="iframe-header">
+                    <h2 id="current-item-title">X Messages</h2>
+                    <div class="current-item-info" id="current-item-info">
+                        Embedded X interface - log in to access your direct messages
+                    </div>
+                </div>
+                <iframe id="x-iframe" src="https://twitter.com/messages"></iframe>
+            </div>
+        </div>
+    </div>
+
+    <script>
+        // Sample X DMs (in a real app, fetch from X API)
+        const xDMs = [
+            { user: 'Tech Expert', username: 'techexpert', preview: 'Thanks for the follow! Would love...', time: '10m ago' },
+            { user: 'Design Pro', username: 'designpro', preview: 'Your recent thread was really...', time: '30m ago' },
+            { user: 'Code Master', username: 'codemaster', preview: 'Can I ask you about your tech...', time: '1h ago' },
+            { user: 'Data Science', username: 'datascience', preview: 'Great work on your latest project!', time: '3h ago' },
+            { user: 'DevOps', username: 'devops', preview: 'Would you be interested in a...', time: '4h ago' },
+            { user: 'UX Designer', username: 'uxdesigner', preview: 'I have a question about your...', time: '6h ago' }
+        ];
+
+        let currentIndex = -1;
+
+        function renderList() {
+            const listContainer = document.getElementById('item-list');
+            listContainer.innerHTML = '';
+
+            xDMs.forEach((dm, index) => {
+                const itemEl = document.createElement('div');
+                itemEl.className = `list-item ${index === currentIndex ? 'active' : ''}`;
+                itemEl.innerHTML = `
+                    <div class="list-item-header">
+                        <div class="list-item-source">@${dm.username}</div>
+                        <div class="list-item-time">${dm.time}</div>
+                    </div>
+                    <div class="list-item-title">${dm.user}</div>
+                    <div class="list-item-preview">${dm.preview}</div>
+                `;
+                itemEl.onclick = () => selectItem(index);
+                listContainer.appendChild(itemEl);
+            });
+
+            document.getElementById('queue-count').textContent = xDMs.length;
+        }
+
+        function selectItem(index) {
+            currentIndex = index;
+            const dm = xDMs[index];
+
+            document.getElementById('current-item-title').textContent = `DM with ${dm.user}`;
+            document.getElementById('current-item-info').textContent = `@${dm.username} - ${dm.time}`;
+
+            renderList();
+        }
+
+        // Initial render
+        renderList();
+    </script>
+</body>
+</html>

--- a/shared/css/operator.css
+++ b/shared/css/operator.css
@@ -1,0 +1,548 @@
+/* Reset and Base Styles */
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+:root {
+    --primary-color: #2563eb;
+    --primary-hover: #1d4ed8;
+    --secondary-color: #64748b;
+    --secondary-hover: #475569;
+    --success-color: #10b981;
+    --background: #f8fafc;
+    --surface: #ffffff;
+    --border: #e2e8f0;
+    --text-primary: #0f172a;
+    --text-secondary: #64748b;
+    --shadow: 0 1px 3px 0 rgb(0 0 0 / 0.1), 0 1px 2px -1px rgb(0 0 0 / 0.1);
+    --shadow-lg: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+}
+
+body {
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+    background: var(--background);
+    color: var(--text-primary);
+    line-height: 1.6;
+    overflow: hidden;
+}
+
+/* App Container */
+.app {
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+}
+
+/* Header */
+.header {
+    background: var(--surface);
+    border-bottom: 1px solid var(--border);
+    padding: 1rem 2rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    box-shadow: var(--shadow);
+    z-index: 10;
+}
+
+.header h1 {
+    font-size: 1.5rem;
+    font-weight: 700;
+    color: var(--primary-color);
+}
+
+.controls {
+    display: flex;
+    gap: 2rem;
+    align-items: center;
+}
+
+.view-toggle {
+    display: flex;
+    gap: 0.5rem;
+    background: var(--background);
+    padding: 0.25rem;
+    border-radius: 0.5rem;
+}
+
+.toggle-btn {
+    padding: 0.5rem 1rem;
+    border: none;
+    background: transparent;
+    color: var(--text-secondary);
+    font-weight: 500;
+    border-radius: 0.375rem;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.toggle-btn:hover {
+    background: var(--surface);
+}
+
+.toggle-btn.active {
+    background: var(--surface);
+    color: var(--primary-color);
+    box-shadow: var(--shadow);
+}
+
+.queue-info {
+    font-weight: 600;
+    color: var(--text-secondary);
+}
+
+.queue-count {
+    color: var(--text-primary);
+}
+
+/* Main Content */
+.main-content {
+    display: flex;
+    flex: 1;
+    overflow: hidden;
+}
+
+/* Sidebar (List Mode) */
+.sidebar {
+    width: 350px;
+    background: var(--surface);
+    border-right: 1px solid var(--border);
+    display: none;
+    flex-direction: column;
+    overflow: hidden;
+}
+
+.sidebar.active {
+    display: flex;
+}
+
+.sidebar-header {
+    padding: 1.5rem;
+    border-bottom: 1px solid var(--border);
+}
+
+.sidebar-header h2 {
+    font-size: 1.25rem;
+    font-weight: 600;
+}
+
+.card-list {
+    flex: 1;
+    overflow-y: auto;
+    padding: 0.5rem;
+}
+
+.list-item {
+    padding: 1rem;
+    margin-bottom: 0.5rem;
+    background: var(--background);
+    border: 2px solid var(--border);
+    border-radius: 0.5rem;
+    cursor: pointer;
+    transition: all 0.2s;
+}
+
+.list-item:hover {
+    border-color: var(--primary-color);
+    transform: translateX(4px);
+}
+
+.list-item.active {
+    background: var(--primary-color);
+    color: white;
+    border-color: var(--primary-color);
+}
+
+.list-item-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 0.5rem;
+}
+
+.list-item-source {
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+}
+
+.list-item-time {
+    font-size: 0.75rem;
+    opacity: 0.7;
+}
+
+.list-item-title {
+    font-weight: 600;
+    margin-bottom: 0.25rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.list-item-preview {
+    font-size: 0.875rem;
+    opacity: 0.8;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+/* Card Container */
+.card-container {
+    flex: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 2rem;
+    overflow: auto;
+}
+
+.card-container.focus-mode {
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+}
+
+/* Empty State */
+.empty-state {
+    text-align: center;
+    color: var(--text-secondary);
+}
+
+.empty-state h2 {
+    font-size: 2rem;
+    margin-bottom: 1rem;
+    color: var(--text-primary);
+}
+
+.empty-state p {
+    font-size: 1.125rem;
+    margin-bottom: 2rem;
+}
+
+/* Card View */
+.card-view {
+    width: 100%;
+    max-width: 800px;
+}
+
+.card {
+    background: var(--surface);
+    border-radius: 1rem;
+    box-shadow: var(--shadow-lg);
+    overflow: hidden;
+    animation: slideIn 0.3s ease-out;
+}
+
+@keyframes slideIn {
+    from {
+        opacity: 0;
+        transform: translateY(20px);
+    }
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
+}
+
+.card-header {
+    padding: 1.5rem;
+    background: var(--background);
+    border-bottom: 1px solid var(--border);
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+}
+
+.card-source {
+    font-size: 0.875rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: var(--primary-color);
+}
+
+.card-time {
+    font-size: 0.875rem;
+    color: var(--text-secondary);
+}
+
+.card-body {
+    padding: 2rem;
+    min-height: 300px;
+}
+
+.card-title {
+    font-size: 1.5rem;
+    font-weight: 700;
+    margin-bottom: 1rem;
+    color: var(--text-primary);
+}
+
+.card-content {
+    font-size: 1rem;
+    color: var(--text-primary);
+    line-height: 1.8;
+}
+
+.card-footer {
+    padding: 1.5rem;
+    background: var(--background);
+    border-top: 1px solid var(--border);
+    display: flex;
+    gap: 1rem;
+}
+
+/* Buttons */
+button {
+    font-family: inherit;
+}
+
+.btn-primary,
+.btn-secondary {
+    flex: 1;
+    padding: 1rem 2rem;
+    font-size: 1rem;
+    font-weight: 600;
+    border: none;
+    border-radius: 0.5rem;
+    cursor: pointer;
+    transition: all 0.2s;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.5rem;
+}
+
+.btn-primary {
+    background: var(--success-color);
+    color: white;
+}
+
+.btn-primary:hover {
+    background: #059669;
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-lg);
+}
+
+.btn-primary:active {
+    transform: translateY(0);
+}
+
+.btn-secondary {
+    background: var(--secondary-color);
+    color: white;
+}
+
+.btn-secondary:hover {
+    background: var(--secondary-hover);
+    transform: translateY(-2px);
+    box-shadow: var(--shadow-lg);
+}
+
+.btn-secondary:active {
+    transform: translateY(0);
+}
+
+.btn-primary span,
+.btn-secondary span {
+    font-size: 1.25rem;
+}
+
+/* Scrollbar Styling */
+::-webkit-scrollbar {
+    width: 8px;
+}
+
+::-webkit-scrollbar-track {
+    background: var(--background);
+}
+
+::-webkit-scrollbar-thumb {
+    background: var(--border);
+    border-radius: 4px;
+}
+
+::-webkit-scrollbar-thumb:hover {
+    background: var(--secondary-color);
+}
+
+/* Auth Prompt */
+.auth-prompt {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
+    padding: 2rem;
+}
+
+.auth-card {
+    background: var(--surface);
+    border-radius: 1rem;
+    padding: 3rem;
+    max-width: 500px;
+    width: 100%;
+    box-shadow: var(--shadow-lg);
+    text-align: center;
+}
+
+.auth-card h2 {
+    font-size: 2rem;
+    margin-bottom: 1rem;
+    color: var(--primary-color);
+}
+
+.auth-card p {
+    color: var(--text-secondary);
+    margin-bottom: 2rem;
+    line-height: 1.6;
+}
+
+/* Loading State */
+.loading-state {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
+    gap: 1rem;
+}
+
+.spinner {
+    width: 50px;
+    height: 50px;
+    border: 4px solid var(--border);
+    border-top-color: var(--primary-color);
+    border-radius: 50%;
+    animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+.loading-state p {
+    color: var(--text-secondary);
+    font-size: 1.125rem;
+}
+
+/* Back Link */
+.header-left {
+    display: flex;
+    align-items: center;
+}
+
+.back-link {
+    color: var(--text-secondary);
+    text-decoration: none;
+    font-size: 0.875rem;
+    transition: color 0.2s;
+}
+
+.back-link:hover {
+    color: var(--primary-color);
+}
+
+/* GitHub-specific styles */
+.issue-labels,
+.pr-labels {
+    display: flex;
+    gap: 0.5rem;
+    margin-top: 1rem;
+    flex-wrap: wrap;
+}
+
+.label {
+    padding: 0.25rem 0.75rem;
+    border-radius: 0.375rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+}
+
+.label.bug {
+    background: #dc2626;
+    color: white;
+}
+
+.label.enhancement {
+    background: #059669;
+    color: white;
+}
+
+.label.documentation {
+    background: #2563eb;
+    color: white;
+}
+
+.user-info {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+    margin-top: 1rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--border);
+}
+
+.user-avatar {
+    width: 32px;
+    height: 32px;
+    border-radius: 50%;
+}
+
+.user-name {
+    font-weight: 600;
+    color: var(--text-primary);
+}
+
+/* Message-specific styles */
+.message-content {
+    background: var(--background);
+    padding: 1rem;
+    border-radius: 0.5rem;
+    margin-top: 1rem;
+}
+
+.message-meta {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-top: 1rem;
+    padding-top: 1rem;
+    border-top: 1px solid var(--border);
+    font-size: 0.875rem;
+    color: var(--text-secondary);
+}
+
+/* Responsive */
+@media (max-width: 768px) {
+    .header {
+        flex-direction: column;
+        gap: 1rem;
+        padding: 1rem;
+    }
+
+    .sidebar {
+        width: 100%;
+        max-width: 300px;
+    }
+
+    .card-container {
+        padding: 1rem;
+    }
+
+    .card-body {
+        padding: 1.5rem;
+        min-height: 200px;
+    }
+
+    .card-footer {
+        flex-direction: column;
+    }
+
+    .auth-card {
+        padding: 2rem;
+    }
+}

--- a/shared/js/auth-utils.js
+++ b/shared/js/auth-utils.js
@@ -1,0 +1,287 @@
+// Authentication utilities for various platforms
+
+class AuthManager {
+    constructor(platform) {
+        this.platform = platform;
+        this.tokenKey = `${platform}_access_token`;
+    }
+
+    getToken() {
+        return localStorage.getItem(this.tokenKey);
+    }
+
+    setToken(token) {
+        localStorage.setItem(this.tokenKey, token);
+    }
+
+    clearToken() {
+        localStorage.removeItem(this.tokenKey);
+    }
+
+    isAuthenticated() {
+        return !!this.getToken();
+    }
+}
+
+// GitHub OAuth Configuration
+const GitHubAuth = {
+    clientId: 'YOUR_GITHUB_CLIENT_ID', // Replace with your GitHub OAuth App Client ID
+    redirectUri: window.location.origin + window.location.pathname,
+    scope: 'repo read:user',
+
+    authorize() {
+        const authUrl = `https://github.com/login/oauth/authorize?client_id=${this.clientId}&redirect_uri=${encodeURIComponent(this.redirectUri)}&scope=${encodeURIComponent(this.scope)}`;
+        window.location.href = authUrl;
+    },
+
+    handleCallback() {
+        const urlParams = new URLSearchParams(window.location.search);
+        const code = urlParams.get('code');
+
+        if (code) {
+            // In a real app, exchange code for token on your backend
+            // For demo purposes, we'll simulate authentication
+            console.log('GitHub OAuth code received:', code);
+            return code;
+        }
+        return null;
+    }
+};
+
+// Telegram Auth Configuration
+const TelegramAuth = {
+    botToken: 'YOUR_BOT_TOKEN', // Replace with your Telegram Bot Token
+
+    async authenticate(phone) {
+        // This is a simplified example
+        // In reality, you'd use Telegram's MTProto protocol or Bot API
+        console.log('Telegram authentication for:', phone);
+        return {
+            success: true,
+            message: 'Demo mode: Authentication simulated'
+        };
+    }
+};
+
+// VK API Configuration
+const VKAuth = {
+    appId: 'YOUR_VK_APP_ID', // Replace with your VK App ID
+    redirectUri: window.location.origin + window.location.pathname,
+
+    authorize() {
+        const authUrl = `https://oauth.vk.com/authorize?client_id=${this.appId}&display=page&redirect_uri=${encodeURIComponent(this.redirectUri)}&scope=messages&response_type=token&v=5.131`;
+        window.location.href = authUrl;
+    },
+
+    handleCallback() {
+        const hash = window.location.hash.substring(1);
+        const params = new URLSearchParams(hash);
+        const token = params.get('access_token');
+
+        if (token) {
+            return token;
+        }
+        return null;
+    }
+};
+
+// X (Twitter) OAuth Configuration
+const XAuth = {
+    // X API v2 requires OAuth 2.0 PKCE flow
+    clientId: 'YOUR_X_CLIENT_ID', // Replace with your X API Client ID
+    redirectUri: window.location.origin + window.location.pathname,
+    scope: 'tweet.read users.read dm.read dm.write',
+
+    async authorize() {
+        // Generate code verifier and challenge for PKCE
+        const codeVerifier = this.generateCodeVerifier();
+        const codeChallenge = await this.generateCodeChallenge(codeVerifier);
+
+        sessionStorage.setItem('x_code_verifier', codeVerifier);
+
+        const authUrl = `https://twitter.com/i/oauth2/authorize?response_type=code&client_id=${this.clientId}&redirect_uri=${encodeURIComponent(this.redirectUri)}&scope=${encodeURIComponent(this.scope)}&code_challenge=${codeChallenge}&code_challenge_method=S256`;
+        window.location.href = authUrl;
+    },
+
+    generateCodeVerifier() {
+        const array = new Uint32Array(28);
+        crypto.getRandomValues(array);
+        return Array.from(array, dec => ('0' + dec.toString(16)).substr(-2)).join('');
+    },
+
+    async generateCodeChallenge(verifier) {
+        const encoder = new TextEncoder();
+        const data = encoder.encode(verifier);
+        const hash = await crypto.subtle.digest('SHA-256', data);
+        return btoa(String.fromCharCode(...new Uint8Array(hash)))
+            .replace(/\+/g, '-')
+            .replace(/\//g, '_')
+            .replace(/=+$/, '');
+    },
+
+    handleCallback() {
+        const urlParams = new URLSearchParams(window.location.search);
+        const code = urlParams.get('code');
+
+        if (code) {
+            return code;
+        }
+        return null;
+    }
+};
+
+// Mock data generators for demos
+const MockDataGenerators = {
+    github: {
+        generateIssues(count = 5) {
+            const issues = [];
+            const titles = [
+                'Bug: Login form not responsive on mobile',
+                'Feature Request: Add dark mode support',
+                'Performance: Slow API response times',
+                'Documentation: Update installation guide',
+                'Security: Update dependencies with vulnerabilities'
+            ];
+            const bodies = [
+                'The login form breaks on screens smaller than 768px. Please investigate and fix.',
+                'It would be great to have a dark mode option. Many users have requested this feature.',
+                'API endpoints are taking 3-5 seconds to respond. This needs optimization.',
+                'The installation guide is outdated and missing steps for the new version.',
+                'Several dependencies have known security vulnerabilities and need to be updated.'
+            ];
+
+            for (let i = 0; i < count; i++) {
+                issues.push({
+                    number: 100 + i,
+                    title: titles[i % titles.length],
+                    body: bodies[i % bodies.length],
+                    user: {
+                        login: `user${i + 1}`,
+                        avatar_url: `https://api.dicebear.com/7.x/avataaars/svg?seed=${i}`
+                    },
+                    created_at: new Date(Date.now() - i * 3600000).toISOString(),
+                    labels: i % 2 === 0 ? ['bug'] : ['enhancement'],
+                    state: 'open'
+                });
+            }
+            return issues;
+        },
+
+        generatePullRequests(count = 3) {
+            const prs = [];
+            const titles = [
+                'Fix responsive layout issues',
+                'Add TypeScript support',
+                'Refactor authentication module'
+            ];
+
+            for (let i = 0; i < count; i++) {
+                prs.push({
+                    number: 50 + i,
+                    title: titles[i % titles.length],
+                    body: 'This PR addresses the issues mentioned in the related issue.',
+                    user: {
+                        login: `contributor${i + 1}`,
+                        avatar_url: `https://api.dicebear.com/7.x/avataaars/svg?seed=pr${i}`
+                    },
+                    created_at: new Date(Date.now() - i * 7200000).toISOString(),
+                    state: 'open'
+                });
+            }
+            return prs;
+        }
+    },
+
+    telegram: {
+        generateMessages(count = 8) {
+            const messages = [];
+            const senders = ['Alex', 'Maria', 'John', 'Sarah', 'Mike', 'Emma', 'David', 'Lisa'];
+            const texts = [
+                'Hey! Did you see the presentation I sent yesterday?',
+                'Can we schedule a meeting for tomorrow?',
+                'The project deadline has been moved to next week.',
+                'I have a quick question about the API integration.',
+                'Thanks for your help with the bug fix!',
+                'Are you available for a quick call?',
+                'I sent you the updated design files.',
+                'Let me know if you need any clarification.'
+            ];
+
+            for (let i = 0; i < count; i++) {
+                messages.push({
+                    id: i + 1,
+                    from: {
+                        id: 1000 + i,
+                        first_name: senders[i % senders.length],
+                        username: senders[i % senders.length].toLowerCase()
+                    },
+                    text: texts[i % texts.length],
+                    date: Math.floor(Date.now() / 1000) - (i * 3600),
+                    unread: true
+                });
+            }
+            return messages;
+        }
+    },
+
+    vk: {
+        generateMessages(count = 8) {
+            const messages = [];
+            const senders = ['Dmitry', 'Anna', 'Pavel', 'Olga', 'Igor', 'Natalia', 'Sergey', 'Elena'];
+            const texts = [
+                'Привет! Как дела?',
+                'Ты видел новости о проекте?',
+                'Давай встретимся завтра?',
+                'Отправил тебе документы.',
+                'Спасибо за помощь!',
+                'Можешь позвонить?',
+                'Нужна твоя консультация.',
+                'Всё готово к презентации.'
+            ];
+
+            for (let i = 0; i < count; i++) {
+                messages.push({
+                    id: i + 1,
+                    user_id: 2000 + i,
+                    from_id: 2000 + i,
+                    text: texts[i % texts.length],
+                    date: Math.floor(Date.now() / 1000) - (i * 3600),
+                    first_name: senders[i % senders.length],
+                    read_state: 0
+                });
+            }
+            return messages;
+        }
+    },
+
+    x: {
+        generateDMs(count = 6) {
+            const messages = [];
+            const senders = ['TechExpert', 'DesignPro', 'CodeMaster', 'DataScience', 'DevOps', 'UXDesigner'];
+            const texts = [
+                'Thanks for the follow! Would love to collaborate.',
+                'Your recent thread was really insightful.',
+                'Can I ask you about your tech stack?',
+                'Great work on your latest project!',
+                'Would you be interested in a partnership?',
+                'I have a question about your open source project.'
+            ];
+
+            for (let i = 0; i < count; i++) {
+                messages.push({
+                    id: `dm_${i + 1}`,
+                    sender: {
+                        id: `user_${3000 + i}`,
+                        username: senders[i % senders.length],
+                        name: senders[i % senders.length],
+                        profile_image_url: `https://api.dicebear.com/7.x/avataaars/svg?seed=x${i}`
+                    },
+                    text: texts[i % texts.length],
+                    created_at: new Date(Date.now() - i * 7200000).toISOString(),
+                    read: false
+                });
+            }
+            return messages;
+        }
+    }
+};

--- a/shared/js/operator-ui.js
+++ b/shared/js/operator-ui.js
@@ -1,0 +1,274 @@
+// Operator - Queue-based Decision Making UI with React
+const { useState, useEffect } = React;
+
+// Sample data generator
+const getSampleData = () => [
+    {
+        source: 'Telegram',
+        time: '2 min ago',
+        title: 'Product Launch Discussion',
+        content: 'Hey! I wanted to discuss the timeline for the new product launch. We have three potential dates, and I need your input on which one works best for the marketing campaign. Also, should we coordinate with the sales team first?'
+    },
+    {
+        source: 'Claude Code',
+        time: '5 min ago',
+        title: 'API Implementation Review',
+        content: 'The REST API implementation is complete. I\'ve added authentication, rate limiting, and comprehensive error handling. The code is ready for your review. Should I proceed with deployment to staging?'
+    },
+    {
+        source: 'X (Twitter)',
+        time: '10 min ago',
+        title: 'Partnership Opportunity',
+        content: 'We\'re looking to partner with innovative companies in the AI space. Your recent work caught our attention. Would you be interested in a quick call this week to explore potential collaboration?'
+    },
+    {
+        source: 'VK',
+        time: '15 min ago',
+        title: 'Team Meeting Reschedule',
+        content: 'The Thursday team meeting needs to be rescheduled due to a conflict. Can we move it to Friday at 2 PM? Please confirm if this works for your schedule.'
+    },
+    {
+        source: 'Telegram',
+        time: '20 min ago',
+        title: 'Bug Report - Critical',
+        content: 'Users are reporting issues with the login functionality. The error happens intermittently when using OAuth. This needs immediate attention. Should I create a hotfix branch?'
+    },
+    {
+        source: 'AI Assistant',
+        time: '25 min ago',
+        title: 'Code Optimization Suggestions',
+        content: 'I\'ve analyzed the codebase and found several optimization opportunities that could improve performance by 30-40%. Would you like me to implement these changes or would you prefer to review them first?'
+    },
+    {
+        source: 'Telegram',
+        time: '30 min ago',
+        title: 'Client Feedback',
+        content: 'The client loved the prototype! They have a few minor adjustments they\'d like to see. The main request is to add dark mode support. Should I prioritize this for the next sprint?'
+    },
+    {
+        source: 'X (Twitter)',
+        time: '35 min ago',
+        title: 'Conference Speaking Invitation',
+        content: 'We\'d love to have you speak at TechConf 2024 about your work in AI-assisted development. The event is in San Francisco next month. Are you interested?'
+    }
+];
+
+// Header Component
+function Header({ viewMode, setViewMode, queueLength }) {
+    return (
+        <header className="header">
+            <h1>Operator</h1>
+            <div className="controls">
+                <div className="view-toggle">
+                    <button
+                        className={`toggle-btn ${viewMode === 'focus' ? 'active' : ''}`}
+                        onClick={() => setViewMode('focus')}
+                    >
+                        Focus Mode
+                    </button>
+                    <button
+                        className={`toggle-btn ${viewMode === 'list' ? 'active' : ''}`}
+                        onClick={() => setViewMode('list')}
+                    >
+                        List Mode
+                    </button>
+                </div>
+                <div className="queue-info">
+                    <span className="queue-count">Queue: <span>{queueLength}</span></span>
+                </div>
+            </div>
+        </header>
+    );
+}
+
+// List Item Component
+function ListItem({ item, isActive, onClick }) {
+    return (
+        <div
+            className={`list-item ${isActive ? 'active' : ''}`}
+            onClick={onClick}
+        >
+            <div className="list-item-header">
+                <div className="list-item-source">{item.source}</div>
+                <div className="list-item-time">{item.time}</div>
+            </div>
+            <div className="list-item-title">{item.title}</div>
+            <div className="list-item-preview">
+                {item.content.substring(0, 60)}...
+            </div>
+        </div>
+    );
+}
+
+// Sidebar Component
+function Sidebar({ queue, currentIndex, onSelectCard, isVisible }) {
+    if (!isVisible) return null;
+
+    return (
+        <aside className={`sidebar ${isVisible ? 'active' : ''}`}>
+            <div className="sidebar-header">
+                <h2>Queue</h2>
+            </div>
+            <div className="card-list">
+                {queue.map((item, index) => (
+                    <ListItem
+                        key={index}
+                        item={item}
+                        isActive={index === currentIndex}
+                        onClick={() => onSelectCard(index)}
+                    />
+                ))}
+            </div>
+        </aside>
+    );
+}
+
+// Card Component
+function Card({ card, onDone, onNext }) {
+    return (
+        <div className="card">
+            <div className="card-header">
+                <div className="card-source">{card.source}</div>
+                <div className="card-time">{card.time}</div>
+            </div>
+            <div className="card-body">
+                <h3 className="card-title">{card.title}</h3>
+                <div className="card-content">{card.content}</div>
+            </div>
+            <div className="card-footer">
+                <button className="btn-primary" onClick={onDone}>
+                    <span>✓</span> DONE
+                </button>
+                <button className="btn-secondary" onClick={onNext}>
+                    <span>→</span> NEXT
+                </button>
+            </div>
+        </div>
+    );
+}
+
+// Empty State Component
+function EmptyState({ onAddSample }) {
+    return (
+        <div className="empty-state">
+            <h2>No items in queue</h2>
+            <p>All tasks completed!</p>
+            <button className="btn-secondary" onClick={onAddSample}>
+                Add Sample Items
+            </button>
+        </div>
+    );
+}
+
+// Main App Component
+function App() {
+    const [queue, setQueue] = useState([]);
+    const [currentIndex, setCurrentIndex] = useState(0);
+    const [viewMode, setViewMode] = useState('focus');
+
+    // Load sample data on mount
+    useEffect(() => {
+        setQueue(getSampleData());
+    }, []);
+
+    // Keyboard shortcuts
+    useEffect(() => {
+        const handleKeyDown = (e) => {
+            if (queue.length === 0) return;
+
+            // D key for Done
+            if (e.key === 'd' || e.key === 'D') {
+                e.preventDefault();
+                handleDone();
+            }
+
+            // N key or Right Arrow for Next
+            if (e.key === 'n' || e.key === 'N' || e.key === 'ArrowRight') {
+                e.preventDefault();
+                handleNext();
+            }
+
+            // Left Arrow to go back (in list mode)
+            if (e.key === 'ArrowLeft' && viewMode === 'list' && currentIndex > 0) {
+                e.preventDefault();
+                setCurrentIndex(currentIndex - 1);
+            }
+        };
+
+        document.addEventListener('keydown', handleKeyDown);
+        return () => document.removeEventListener('keydown', handleKeyDown);
+    }, [queue, currentIndex, viewMode]);
+
+    const handleDone = () => {
+        if (queue.length === 0) return;
+
+        const newQueue = [...queue];
+        newQueue.splice(currentIndex, 1);
+        setQueue(newQueue);
+
+        // Adjust index if necessary
+        if (currentIndex >= newQueue.length && currentIndex > 0) {
+            setCurrentIndex(newQueue.length - 1);
+        }
+    };
+
+    const handleNext = () => {
+        if (queue.length === 0) return;
+
+        const newQueue = [...queue];
+        const currentItem = newQueue.splice(currentIndex, 1)[0];
+        newQueue.push(currentItem);
+        setQueue(newQueue);
+
+        // Stay at same index (which now shows the next item)
+        if (currentIndex >= newQueue.length) {
+            setCurrentIndex(0);
+        }
+    };
+
+    const handleSelectCard = (index) => {
+        setCurrentIndex(index);
+    };
+
+    const handleAddSample = () => {
+        setQueue(getSampleData());
+        setCurrentIndex(0);
+    };
+
+    const currentCard = queue[currentIndex];
+
+    return (
+        <div className="app">
+            <Header
+                viewMode={viewMode}
+                setViewMode={setViewMode}
+                queueLength={queue.length}
+            />
+            <div className="main-content">
+                <Sidebar
+                    queue={queue}
+                    currentIndex={currentIndex}
+                    onSelectCard={handleSelectCard}
+                    isVisible={viewMode === 'list'}
+                />
+                <main className={`card-container ${viewMode === 'focus' ? 'focus-mode' : ''}`}>
+                    {queue.length === 0 ? (
+                        <EmptyState onAddSample={handleAddSample} />
+                    ) : (
+                        <div className="card-view">
+                            <Card
+                                card={currentCard}
+                                onDone={handleDone}
+                                onNext={handleNext}
+                            />
+                        </div>
+                    )}
+                </main>
+            </div>
+        </div>
+    );
+}
+
+// Render the app
+const root = ReactDOM.createRoot(document.getElementById('root'));
+root.render(<App />);

--- a/shared/js/ui-components.js
+++ b/shared/js/ui-components.js
@@ -1,0 +1,377 @@
+// Shared React UI Components for Operator demos
+// This file contains reusable components for both list-sidebar and cards-stream modes
+
+const { useState, useEffect } = React;
+
+// Header Component
+function OperatorHeader({ title, queueLength, showBackLink = true }) {
+    return React.createElement('header', { className: 'header' },
+        React.createElement('div', { className: 'header-left' },
+            showBackLink && React.createElement('a', {
+                href: '../../..',
+                className: 'back-link',
+                style: { marginRight: '1rem', color: 'var(--text-secondary)', textDecoration: 'none' }
+            }, '← Back to Demos'),
+            React.createElement('h1', null, title)
+        ),
+        React.createElement('div', { className: 'controls' },
+            React.createElement('div', { className: 'queue-info' },
+                React.createElement('span', { className: 'queue-count' },
+                    'Queue: ',
+                    React.createElement('span', null, queueLength)
+                )
+            )
+        )
+    );
+}
+
+// List Item Component for Sidebar
+function ListItem({ item, isActive, onClick, renderPreview }) {
+    return React.createElement('div', {
+        className: `list-item ${isActive ? 'active' : ''}`,
+        onClick: onClick
+    },
+        React.createElement('div', { className: 'list-item-header' },
+            React.createElement('div', { className: 'list-item-source' }, item.source || item.type),
+            React.createElement('div', { className: 'list-item-time' }, item.time || item.timeAgo)
+        ),
+        React.createElement('div', { className: 'list-item-title' }, item.title),
+        renderPreview ? renderPreview(item) :
+            React.createElement('div', { className: 'list-item-preview' },
+                (item.content || item.body || '').substring(0, 60) + '...'
+            )
+    );
+}
+
+// Sidebar Component for List Mode
+function Sidebar({ queue, currentIndex, onSelectCard }) {
+    return React.createElement('aside', { className: 'sidebar active' },
+        React.createElement('div', { className: 'sidebar-header' },
+            React.createElement('h2', null, 'Queue')
+        ),
+        React.createElement('div', { className: 'card-list' },
+            queue.map((item, index) =>
+                React.createElement(ListItem, {
+                    key: index,
+                    item: item,
+                    isActive: index === currentIndex,
+                    onClick: () => onSelectCard(index)
+                })
+            )
+        )
+    );
+}
+
+// Card Component
+function Card({ card, onDone, onNext, renderContent }) {
+    return React.createElement('div', { className: 'card' },
+        React.createElement('div', { className: 'card-header' },
+            React.createElement('div', { className: 'card-source' }, card.source || card.type),
+            React.createElement('div', { className: 'card-time' }, card.time || card.timeAgo)
+        ),
+        React.createElement('div', { className: 'card-body' },
+            React.createElement('h3', { className: 'card-title' }, card.title),
+            renderContent ? renderContent(card) :
+                React.createElement('div', { className: 'card-content' }, card.content || card.body)
+        ),
+        React.createElement('div', { className: 'card-footer' },
+            React.createElement('button', {
+                className: 'btn-primary',
+                onClick: onDone
+            },
+                React.createElement('span', null, '✓'),
+                ' DONE'
+            ),
+            React.createElement('button', {
+                className: 'btn-secondary',
+                onClick: onNext
+            },
+                React.createElement('span', null, '→'),
+                ' NEXT'
+            )
+        )
+    );
+}
+
+// Empty State Component
+function EmptyState({ message, onAction, actionLabel }) {
+    return React.createElement('div', { className: 'empty-state' },
+        React.createElement('h2', null, message || 'No items in queue'),
+        React.createElement('p', null, 'All tasks completed!'),
+        onAction && React.createElement('button', {
+            className: 'btn-secondary',
+            onClick: onAction
+        }, actionLabel || 'Reload')
+    );
+}
+
+// Authentication Component
+function AuthPrompt({ platform, onAuthenticate, customMessage }) {
+    return React.createElement('div', { className: 'auth-prompt' },
+        React.createElement('div', { className: 'auth-card' },
+            React.createElement('h2', null, `${platform} Authentication`),
+            React.createElement('p', null, customMessage || `Please authenticate with ${platform} to access your data.`),
+            React.createElement('button', {
+                className: 'btn-primary',
+                onClick: onAuthenticate,
+                style: { marginTop: '1rem', width: '100%' }
+            }, `Connect ${platform}`)
+        )
+    );
+}
+
+// Loading Component
+function LoadingSpinner({ message }) {
+    return React.createElement('div', { className: 'loading-state' },
+        React.createElement('div', { className: 'spinner' }),
+        message && React.createElement('p', null, message)
+    );
+}
+
+// List-Sidebar Mode App Component
+function ListSidebarApp({
+    title,
+    fetchData,
+    renderContent,
+    renderPreview,
+    platform
+}) {
+    const [queue, setQueue] = useState([]);
+    const [currentIndex, setCurrentIndex] = useState(0);
+    const [loading, setLoading] = useState(true);
+    const [authenticated, setAuthenticated] = useState(false);
+
+    useEffect(() => {
+        loadData();
+    }, []);
+
+    useEffect(() => {
+        const handleKeyDown = (e) => {
+            if (queue.length === 0) return;
+
+            if (e.key === 'd' || e.key === 'D') {
+                e.preventDefault();
+                handleDone();
+            }
+
+            if (e.key === 'n' || e.key === 'N' || e.key === 'ArrowRight') {
+                e.preventDefault();
+                handleNext();
+            }
+
+            if (e.key === 'ArrowLeft' && currentIndex > 0) {
+                e.preventDefault();
+                setCurrentIndex(currentIndex - 1);
+            }
+        };
+
+        document.addEventListener('keydown', handleKeyDown);
+        return () => document.removeEventListener('keydown', handleKeyDown);
+    }, [queue, currentIndex]);
+
+    const loadData = async () => {
+        setLoading(true);
+        try {
+            const data = await fetchData();
+            setQueue(data);
+            setAuthenticated(true);
+        } catch (error) {
+            console.error('Error loading data:', error);
+            setAuthenticated(false);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleDone = () => {
+        if (queue.length === 0) return;
+
+        const newQueue = [...queue];
+        newQueue.splice(currentIndex, 1);
+        setQueue(newQueue);
+
+        if (currentIndex >= newQueue.length && currentIndex > 0) {
+            setCurrentIndex(newQueue.length - 1);
+        }
+    };
+
+    const handleNext = () => {
+        if (queue.length === 0) return;
+
+        const newQueue = [...queue];
+        const currentItem = newQueue.splice(currentIndex, 1)[0];
+        newQueue.push(currentItem);
+        setQueue(newQueue);
+
+        if (currentIndex >= newQueue.length) {
+            setCurrentIndex(0);
+        }
+    };
+
+    const handleSelectCard = (index) => {
+        setCurrentIndex(index);
+    };
+
+    const currentCard = queue[currentIndex];
+
+    if (loading) {
+        return React.createElement('div', { className: 'app' },
+            React.createElement(LoadingSpinner, { message: 'Loading...' })
+        );
+    }
+
+    if (!authenticated) {
+        return React.createElement('div', { className: 'app' },
+            React.createElement(AuthPrompt, {
+                platform: platform,
+                onAuthenticate: loadData
+            })
+        );
+    }
+
+    return React.createElement('div', { className: 'app' },
+        React.createElement(OperatorHeader, {
+            title: title,
+            queueLength: queue.length
+        }),
+        React.createElement('div', { className: 'main-content' },
+            React.createElement(Sidebar, {
+                queue: queue,
+                currentIndex: currentIndex,
+                onSelectCard: handleSelectCard,
+                renderPreview: renderPreview
+            }),
+            React.createElement('main', { className: 'card-container' },
+                queue.length === 0 ?
+                    React.createElement(EmptyState, {
+                        onAction: loadData,
+                        actionLabel: 'Reload Data'
+                    }) :
+                    React.createElement('div', { className: 'card-view' },
+                        React.createElement(Card, {
+                            card: currentCard,
+                            onDone: handleDone,
+                            onNext: handleNext,
+                            renderContent: renderContent
+                        })
+                    )
+            )
+        )
+    );
+}
+
+// Cards Stream (Focus) Mode App Component
+function CardsStreamApp({
+    title,
+    fetchData,
+    renderContent,
+    platform
+}) {
+    const [queue, setQueue] = useState([]);
+    const [currentIndex, setCurrentIndex] = useState(0);
+    const [loading, setLoading] = useState(true);
+    const [authenticated, setAuthenticated] = useState(false);
+
+    useEffect(() => {
+        loadData();
+    }, []);
+
+    useEffect(() => {
+        const handleKeyDown = (e) => {
+            if (queue.length === 0) return;
+
+            if (e.key === 'd' || e.key === 'D') {
+                e.preventDefault();
+                handleDone();
+            }
+
+            if (e.key === 'n' || e.key === 'N' || e.key === 'ArrowRight') {
+                e.preventDefault();
+                handleNext();
+            }
+        };
+
+        document.addEventListener('keydown', handleKeyDown);
+        return () => document.removeEventListener('keydown', handleKeyDown);
+    }, [queue, currentIndex]);
+
+    const loadData = async () => {
+        setLoading(true);
+        try {
+            const data = await fetchData();
+            setQueue(data);
+            setAuthenticated(true);
+        } catch (error) {
+            console.error('Error loading data:', error);
+            setAuthenticated(false);
+        } finally {
+            setLoading(false);
+        }
+    };
+
+    const handleDone = () => {
+        if (queue.length === 0) return;
+
+        const newQueue = [...queue];
+        newQueue.splice(currentIndex, 1);
+        setQueue(newQueue);
+
+        if (currentIndex >= newQueue.length && currentIndex > 0) {
+            setCurrentIndex(newQueue.length - 1);
+        }
+    };
+
+    const handleNext = () => {
+        if (queue.length === 0) return;
+
+        const newQueue = [...queue];
+        const currentItem = newQueue.splice(currentIndex, 1)[0];
+        newQueue.push(currentItem);
+        setQueue(newQueue);
+
+        if (currentIndex >= newQueue.length) {
+            setCurrentIndex(0);
+        }
+    };
+
+    const currentCard = queue[currentIndex];
+
+    if (loading) {
+        return React.createElement('div', { className: 'app' },
+            React.createElement(LoadingSpinner, { message: 'Loading...' })
+        );
+    }
+
+    if (!authenticated) {
+        return React.createElement('div', { className: 'app' },
+            React.createElement(AuthPrompt, {
+                platform: platform,
+                onAuthenticate: loadData
+            })
+        );
+    }
+
+    return React.createElement('div', { className: 'app' },
+        React.createElement(OperatorHeader, {
+            title: title,
+            queueLength: queue.length
+        }),
+        React.createElement('div', { className: 'main-content' },
+            React.createElement('main', { className: 'card-container focus-mode' },
+                queue.length === 0 ?
+                    React.createElement(EmptyState, {
+                        onAction: loadData,
+                        actionLabel: 'Reload Data'
+                    }) :
+                    React.createElement('div', { className: 'card-view' },
+                        React.createElement(Card, {
+                            card: currentCard,
+                            onDone: handleDone,
+                            onNext: handleNext,
+                            renderContent: renderContent
+                        })
+                    )
+            )
+        )
+    );
+}


### PR DESCRIPTION
This commit adds:
- New landing page (index.html) to select from all available demos
- Organized folder structure:
  - list-sidebar/ - UI with sidebar list + main content area
  - cards-stream/ - Focus mode UI with one card at a time
  - Each has api/ and iframe/ variants for different integration approaches
  - Each variant supports 4 platforms: GitHub, Telegram, VK, X (Twitter)

- Shared utilities:
  - shared/css/operator.css - Common styles for all demos
  - shared/js/auth-utils.js - Authentication helpers and mock data generators
  - shared/js/ui-components.js - Reusable React components
  - shared/js/operator-ui.js - Original UI code (preserved)

Features:
- 16 unique demo configurations (2 UI modes × 2 integration types × 4 platforms)
- API demos: Direct integration with platform APIs (using mock data for demo)
- IFRAME demos: Embedded web interfaces of actual platforms
- Focus on unread/unprocessed items:
  - GitHub: Issues and Pull Requests
  - Telegram/VK/X: Private messages and DMs
- Keyboard shortcuts: D for Done, N for Next
- React.js based with functional components
- All demos accessible from the landing page